### PR TITLE
윈도우시스템에서도 웹에디터로 올린 이미지를 볼수있게 코드추가 및 MySql Closed방지

### DIFF
--- a/backend/portal-service/src/main/java/org/egovframe/cloud/portalservice/service/attachment/AttachmentService.java
+++ b/backend/portal-service/src/main/java/org/egovframe/cloud/portalservice/service/attachment/AttachmentService.java
@@ -150,7 +150,12 @@ public class AttachmentService extends AbstractService {
      */
     @Transactional(readOnly = true)
     public AttachmentImageResponseDto loadImage(String imagename) {
-        return storageUtils.loadImage(imagename.replaceAll(EDITOR_FILE_SEPARATOR, FILE_SEPARATOR));
+    	if(FILE_SEPARATOR.equals("\\")) {//윈도우기반 자바시스템일 때 하이픈 character to be escaped is missing 에러방지
+    		imagename = imagename.replaceAll(EDITOR_FILE_SEPARATOR, "\\\\"); //getFileSystem().getPath에서 디스크의 경로를 사용할 때 
+    	} else { //리눅스 또는 맥 기반 자바시스템 경로일 때(아래)
+    		imagename = imagename.replaceAll(EDITOR_FILE_SEPARATOR, FILE_SEPARATOR);
+    	}
+        return storageUtils.loadImage(imagename);
     }
 
     /**

--- a/config/board-service.yml
+++ b/config/board-service.yml
@@ -3,7 +3,7 @@ database:
 
 spring:
   datasource:
-    url: ${database.url}?serverTimezone=Asia/Seoul
+    url: ${database.url}?serverTimezone=Asia/Seoul&autoReconnect=true&validationQuery=select 1
     username: msaportal
     password: msaportal
     driver-class-name: com.mysql.cj.jdbc.Driver

--- a/config/portal-service.yml
+++ b/config/portal-service.yml
@@ -3,7 +3,7 @@ database:
 
 spring:
   datasource:
-    url: ${database.url}?serverTimezone=Asia/Seoul
+    url: ${database.url}?serverTimezone=Asia/Seoul&autoReconnect=true&validationQuery=select 1
     username: msaportal
     password: msaportal
     driver-class-name: com.mysql.cj.jdbc.Driver

--- a/config/user-service.yml
+++ b/config/user-service.yml
@@ -3,7 +3,7 @@ database:
 
 spring:
   datasource:
-    url: ${database.url}?serverTimezone=Asia/Seoul
+    url: ${database.url}?serverTimezone=Asia/Seoul&autoReconnect=true&validationQuery=select 1
     username: msaportal
     password: msaportal
     driver-class-name: com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
## 수정 사유 Reason for modification
- 웹에디터에서 올린 이미지 경로를 윈도우 파일시스템에서도 볼수 있도록 코드를 추가
- 윈도우 시스템에서는 웹데이터에서 올린 이미지를 불러올 때 아래와 같은 자바 에러가 표시된다. 그래서 수정해 보았습니다.(아래 콘솔의 에러메세지)
```
[ApiLogInterceptor  preHandle] GET, /api/v1/images/editor/editor-202110-1ca352474cd84341a1668e09f5aa968a.png, 200
handleException
java.lang.IllegalArgumentException: character to be escaped is missing
```
- 교육용 소스 작업 시 MySql 커넥션이 Closed 되는 상황이 발생 되어서 연결이 끊어 지지 않도록 config서버의 -service.yml 파일에 아래 내용을 추가했습니다.
- &autoReconnect=true&validationQuery=select 1

관리자께서 이번 작업 merge 해 주시면, 앞으로 윈도우 파일시스템에서 에러를 방지하는 코드 3가지와 추가사항 3가지 더 작업할 예정 입니다.(아래 작업 예정 목록)
1. 윈도우시스템에서 다국어 메세지 경로를 사용 가능하게 추가(예정)
2. 윈도우 시스템에서도 파일스토리지의 경로를 사용가능하게 추가(예정)
3. 윈도우기반 자바시스템일 때 업로드 시 Temp폴더의 delete file 에러방지코드 추가(예정)
4. 포털 실행 방법 ts-node로 시작하게 변화: 실행 속도 향상(예정)
5. 넥스트js 포털사이트의 배너 출력 시 타이클과 더보기 링크가 밝은 색상에서도 보이게 css처리(예정)
6. 넥스트js 포털사이트의 묻고답하기 신규 등록시 첨부파일 업로드의 post 테이블에 attachmentCode 누락되는 부분 추가(예정)

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [X] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [x] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.
- 포털서비스프로젝트의 AttachementService.java 라인153번
```
if(FILE_SEPARATOR.equals("\\")) {//윈도우기반 자바시스템일 때 하이픈 character to be escaped is missing 에러방지
	imagename = imagename.replaceAll(EDITOR_FILE_SEPARATOR, "\\\\"); //getFileSystem().getPath에서 디스크의 경로를 사용할 때 
} else { //리눅스 또는 맥 기반 자바시스템 경로일 때(아래)
	imagename = imagename.replaceAll(EDITOR_FILE_SEPARATOR, FILE_SEPARATOR);
}
return storageUtils.loadImage(imagename);
```
- 작업 중 MySql 커넥션이 Closed 되는 상황 때문에 연결이 끊어 지지 않도록 config서버에 board-service.yml, portal-service.yml, user-service.yml 파일에 아래 내용 추가
- &autoReconnect=true&validationQuery=select 1
```
url: ${database.url}?serverTimezone=Asia/Seoul&autoReconnect=true&validationQuery=select 1
```
## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [X] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡쳐 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡쳐 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.
- 우선 테스트를 위해서 사용자 홈 폴더에 생성된 msa-attach-volumn 폴더에 editor/202110/1ca352474cd84341a1668e09f5aa968a.png 파일을 생성한다.(아래)
![image](https://github.com/eGovFramework/egovframe-msa-edu/assets/52336625/4a3fd051-f1ba-4d21-b206-730548fb8473)
- 소스 수정 전 윈도우 시스템에서 소개 페이지의 이미지가 엑박으로 표시된다.(아래)
![image](https://github.com/eGovFramework/egovframe-msa-edu/assets/52336625/06b420aa-5efa-4be7-ad85-c086998e0569)
- 소스 수정 후 윈도우 시스템에서 소개 페이지의 이미지가 정상으로 표시된다.(아래)
![image](https://github.com/eGovFramework/egovframe-msa-edu/assets/52336625/55202f00-9172-451c-a0f3-d9ffd4db6098)
