### PR TITLE
[2024년 전자정부 표준프레임워크 컨트리뷰션][MSA 템플릿 (교육용)] module-common org.webjars 가…

### DIFF
--- a/backend/module-common/build.gradle
+++ b/backend/module-common/build.gradle
@@ -76,6 +76,9 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.projectreactor:reactor-test'
     testImplementation 'org.springframework.security:spring-security-test'
+
+    // https://mvnrepository.com/artifact/org.webjars/webjars-locator-core
+    implementation group: 'org.webjars', name: 'webjars-locator-core', version: '0.59'
 }
 
 dependencyManagement {


### PR DESCRIPTION
…져오기를 확인할 수 없습니다.

## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

### module-common org.webjars 가져오기를 확인할 수 없습니다.

org.webjars:webjars-locator-core:0.59 추가해도 될까요?

이클립스 문제(Problems)
```
Description	Resource	Path	Location	Type
Class<NotFoundException> cannot be resolved to a type	ExceptionHandlerAdvice.java	/module-common/src/main/java/org/egovframe/cloud/reactive/exception	line 98	Java Problem
NotFoundException cannot be resolved to a type	ExceptionHandlerAdvice.java	/module-common/src/main/java/org/egovframe/cloud/reactive/exception	line 98	Java Problem
NotFoundException cannot be resolved to a type	ExceptionHandlerAdvice.java	/module-common/src/main/java/org/egovframe/cloud/reactive/exception	line 100	Java Problem
The import org.webjars cannot be resolved	ExceptionHandlerAdvice.java	/module-common/src/main/java/org/egovframe/cloud/reactive/exception	line 22	Java Problem
Newer patch version of Spring Boot available: 2.7.18	build.gradle	/module-common	line 1	Language Servers
Project 'module-common' has no explicit encoding set	module-common		/module-common	No explicit project encoding
The import lombok.extern.slf4j.Slf4j is never used	LeaveaTraceConfig.java	/module-common/src/main/java/org/egovframe/cloud/common/config	line 3	Java Problem
The import org.springframework.beans.factory.annotation.Autowired is never used	AbstractService.java	/module-common/src/main/java/org/egovframe/cloud/common/service	line 8	Java Problem
The serializable class BusinessException does not declare a static final serialVersionUID field of type long	BusinessException.java	/module-common/src/main/java/org/egovframe/cloud/common/exception	line 25	Java Problem
The serializable class BusinessMessageException does not declare a static final serialVersionUID field of type long	BusinessMessageException.java	/module-common/src/main/java/org/egovframe/cloud/common/exception	line 22	Java Problem
The serializable class EntityNotFoundException does not declare a static final serialVersionUID field of type long	EntityNotFoundException.java	/module-common/src/main/java/org/egovframe/cloud/common/exception	line 23	Java Problem
The serializable class InvalidValueException does not declare a static final serialVersionUID field of type long	InvalidValueException.java	/module-common/src/main/java/org/egovframe/cloud/common/exception	line 23	Java Problem
The value of the field ApiLogService.log is not used	ApiLogService.java	/module-common/src/main/java/org/egovframe/cloud/servlet/service	line 33	Java Problem
The value of the field AuthenticationConverter.log is not used	AuthenticationConverter.java	/module-common/src/main/java/org/egovframe/cloud/reactive/config	line 40	Java Problem
```

import org.webjars.NotFoundException;

The import org.webjars cannot be resolved

org.webjars 가져오기를 확인할 수 없습니다.


https://mvnrepository.com/artifact/org.webjars/webjars-locator-core/0.59

Gradle
```
// https://mvnrepository.com/artifact/org.webjars/webjars-locator-core
implementation group: 'org.webjars', name: 'webjars-locator-core', version: '0.59'
```

Gradle (Short)
```
// https://mvnrepository.com/artifact/org.webjars/webjars-locator-core
implementation 'org.webjars:webjars-locator-core:0.59'
```

/module-common/build.gradle

[2024년 전자정부 표준프레임워크 컨트리뷰션] module-common org.webjars 가져오기를 확인할 수 없습니다.

[2024년 전자정부 표준프레임워크 컨트리뷰션][MSA 템플릿 (교육용)] module-common org.webjars 가져오기를 확인할 수 없습니다.

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

테스트 전의 스크린샷
![image](https://github.com/user-attachments/assets/3888770e-d47d-4f06-a797-6c6b599b4293)

테스트 후의 스크린샷
![image](https://github.com/user-attachments/assets/5492d09c-f1bd-45d2-bc67-569fb633e3d8)

https://youtu.be/pA1c8Xf1Ldk
