### PR TITLE
 selfLink was empty. Troubleshooting

### DIFF
--- a/k8s/environments/nfs/deployment.yaml
+++ b/k8s/environments/nfs/deployment.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: nfs-provisioner-sa
       containers:
         - name: nfs-provisioner
-          image: quay.io/external_storage/nfs-client-provisioner:latest
+          image: gcr.io/k8s-staging-sig-storage/nfs-subdir-external-provisioner:v4.0.2
           env:
             - name: PROVISIONER_NAME
               value: nfs-provisioner


### PR DESCRIPTION
Resolving the following errors that occur after Kubernetes 1.20: unexpected error getting claim reference: selfLink was empty, can't make reference

## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

핵심 오류
unexpected error getting claim reference: selfLink was empty, can't make reference
Kubernetes 1.20 이후부터는 selfLink가 기본적으로 제거(disabled) 되었고, 이로 인해 해당 오류가 발생한다고 알려져 있습니다.
quay.io/external_storage/nfs-client-provisioner는 레거시 프로젝트로서, 더 이상 업데이트되지 않으며 selfLink 제거와 같은 최신 Kubernetes API 변경사항을 반영하지 않습니다.

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [x] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.
