### PR TITLE
[chore] jjwt 0.12.6 → 0.13.0 일괄 업그레이드 (8개 서비스)

### DIFF
--- a/backend/apigateway/build.gradle
+++ b/backend/apigateway/build.gradle
@@ -30,9 +30,9 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-bootstrap' // config
     implementation 'org.springframework.cloud:spring-cloud-starter-bus-amqp'  // bus
     implementation 'net.logstash.logback:logstash-logback-encoder:7.4'        // logstash logback
-    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
-    implementation 'io.jsonwebtoken:jjwt-impl:0.12.6'
-    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+    implementation 'io.jsonwebtoken:jjwt-api:0.13.0'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.13.0'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.13.0'
     implementation 'jakarta.xml.bind:jakarta.xml.bind-api:4.0.0'
     runtimeOnly 'javax.xml.bind:jaxb-api:2.3.1'
     runtimeOnly 'org.glassfish.jaxb:jaxb-runtime:2.3.6'

--- a/backend/apigateway/src/main/java/org/egovframe/cloud/apigateway/config/WebFluxSecurityConfig.java
+++ b/backend/apigateway/src/main/java/org/egovframe/cloud/apigateway/config/WebFluxSecurityConfig.java
@@ -5,11 +5,14 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.authorization.ReactiveAuthorizationManager;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
 import org.springframework.security.web.server.SecurityWebFilterChain;
 import org.springframework.security.web.server.authentication.HttpStatusServerEntryPoint;
 import org.springframework.security.web.server.authorization.AuthorizationContext;
+import org.springframework.security.web.server.header.ReferrerPolicyServerHttpHeadersWriter.ReferrerPolicy;
+import org.springframework.security.web.server.header.XFrameOptionsServerHttpHeadersWriter.Mode;
 
 /**
  * org.egovframe.cloud.apigateway.config.WebFluxSecurityConfig
@@ -54,15 +57,19 @@ public class WebFluxSecurityConfig {
      */
     @Bean
     public SecurityWebFilterChain configure(ServerHttpSecurity http, ReactiveAuthorizationManager<AuthorizationContext> check) throws Exception {
-    	http
-                .csrf(csrf -> csrf.disable())
-                .headers(headers -> headers.frameOptions(frameOptions -> frameOptions.disable()))
-                .formLogin(formLogin -> formLogin.disable())
-                .httpBasic(httpBasic -> httpBasic.authenticationEntryPoint(new HttpStatusServerEntryPoint(HttpStatus.UNAUTHORIZED))) // login dialog disabled & 401 HttpStatus return
-                .authorizeExchange(exchanges -> exchanges
-                        .pathMatchers(PERMITALL_ANTPATTERNS).permitAll()
-                        .pathMatchers(HttpMethod.POST, USER_JOIN_ANTPATTERNS).permitAll()
-                        .anyExchange().access(check));
+        http.headers(headers -> headers
+                .frameOptions(frameOptions -> frameOptions.mode(Mode.DENY))
+                .contentTypeOptions(Customizer.withDefaults())
+                .referrerPolicy(referrer -> referrer.policy(ReferrerPolicy.SAME_ORIGIN))
+                .contentSecurityPolicy(cps -> cps.policyDirectives("default-src 'self'; frame-ancestors 'none'; base-uri 'self'")));
+
+    	http.csrf(csrf -> csrf.disable())
+            .formLogin(formLogin -> formLogin.disable())
+            .httpBasic(httpBasic -> httpBasic.authenticationEntryPoint(new HttpStatusServerEntryPoint(HttpStatus.UNAUTHORIZED))) // login dialog disabled & 401 HttpStatus return
+            .authorizeExchange(exchanges -> exchanges
+                .pathMatchers(PERMITALL_ANTPATTERNS).permitAll()
+                .pathMatchers(HttpMethod.POST, USER_JOIN_ANTPATTERNS).permitAll()
+                .anyExchange().access(check));
 
         return http.build();
     }

--- a/backend/apigateway/src/main/resources/application.yml
+++ b/backend/apigateway/src/main/resources/application.yml
@@ -80,9 +80,14 @@ springdoc:
 # config server actuator
 management:
   endpoints:
+    access:
+      default: read-only # 기본적으로 모든 엔드포인트를 읽기 전용으로 설정
+    jmx:
+      exposure:
+        exclude: "*" # JMX에서 모든 엔드포인트 비활성화
     web:
       exposure:
-        include: refresh, health, beans, info
+        include: health, info
 
 info:
   app:

--- a/backend/board-service/build.gradle
+++ b/backend/board-service/build.gradle
@@ -53,9 +53,9 @@ dependencies {
 
     implementation 'net.logstash.logback:logstash-logback-encoder:7.4'        // logstash logback
     implementation 'com.mysql:mysql-connector-j:8.4.0'
-    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
-    implementation 'io.jsonwebtoken:jjwt-impl:0.12.6'
-    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+    implementation 'io.jsonwebtoken:jjwt-api:0.13.0'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.13.0'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.13.0'
 
     // querydsl
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'

--- a/backend/board-service/src/main/java/org/egovframe/cloud/boardservice/api/posts/dto/PostsListResponseDto.java
+++ b/backend/board-service/src/main/java/org/egovframe/cloud/boardservice/api/posts/dto/PostsListResponseDto.java
@@ -131,7 +131,11 @@ public class PostsListResponseDto implements Serializable {
         this.createdBy = createdBy;
         this.createdName = createdName;
         this.createdDate = createdDate;
-        this.isNew = createdDate.plusDays(newDisplayDayCount).compareTo(LocalDateTime.now()) >= 0;
+        if (newDisplayDayCount != null && newDisplayDayCount > 0 && this.createdDate != null) {
+            this.isNew = this.createdDate.plusDays(newDisplayDayCount).compareTo(LocalDateTime.now()) >= 0;
+        } else {
+            this.isNew = false;
+        }
         this.commentCount = commentCount;
     }
 

--- a/backend/board-service/src/main/java/org/egovframe/cloud/boardservice/api/posts/dto/PostsResponseDto.java
+++ b/backend/board-service/src/main/java/org/egovframe/cloud/boardservice/api/posts/dto/PostsResponseDto.java
@@ -160,8 +160,12 @@ public class PostsResponseDto implements Serializable {
         this.createdName = createdName;
         this.createdDate = createdDate;
         this.board = board;
-        if (this.board.getNewDisplayDayCount() != null && this.board.getNewDisplayDayCount() > 0) {
-            this.isNew = createdDate.plusDays(this.board.getNewDisplayDayCount()).compareTo(LocalDateTime.now()) <= 0;
+        if (this.board != null
+                && this.board.getNewDisplayDayCount() != null
+                && this.board.getNewDisplayDayCount() > 0
+                && this.createdDate != null) {
+            this.isNew = this.createdDate.plusDays(this.board.getNewDisplayDayCount())
+                    .compareTo(LocalDateTime.now()) >= 0;
         } else {
             this.isNew = false;
         }
@@ -187,8 +191,11 @@ public class PostsResponseDto implements Serializable {
         this.createdName = entity.getCreator() != null ? entity.getCreator().getUserName() : null;
         this.createdDate = entity.getCreatedDate();
         this.board = new BoardResponseDto(entity.getBoard());
-        if (this.board.getNewDisplayDayCount() != null) {
-            this.isNew = createdDate.plusDays(this.board.getNewDisplayDayCount()).compareTo(LocalDateTime.now()) <= 0;
+        if (this.board.getNewDisplayDayCount() != null
+                && this.board.getNewDisplayDayCount() > 0
+                && this.createdDate != null) {
+            this.isNew = this.createdDate.plusDays(this.board.getNewDisplayDayCount())
+                    .compareTo(LocalDateTime.now()) >= 0;
         } else {
             this.isNew = false;
         }

--- a/backend/board-service/src/main/java/org/egovframe/cloud/boardservice/api/posts/dto/PostsSimpleResponseDto.java
+++ b/backend/board-service/src/main/java/org/egovframe/cloud/boardservice/api/posts/dto/PostsSimpleResponseDto.java
@@ -1,7 +1,6 @@
 package org.egovframe.cloud.boardservice.api.posts.dto;
 
 import java.io.Serializable;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import org.egovframe.cloud.boardservice.api.board.dto.BoardResponseDto;
@@ -94,9 +93,9 @@ public class PostsSimpleResponseDto implements Serializable {
      * @return PostsSimpleResponseDto 게시물 응답 DTO
      */
     public PostsSimpleResponseDto setIsNew(BoardResponseDto boardResponseDto) {
-        if (boardResponseDto.getNewDisplayDayCount() != null) {
-            int compareTo = createdDate.toLocalDate().compareTo(LocalDate.now());
-            this.isNew = 0 <= compareTo && compareTo <= boardResponseDto.getNewDisplayDayCount();
+        Integer dayCount = boardResponseDto != null ? boardResponseDto.getNewDisplayDayCount() : null;
+        if (dayCount != null && dayCount > 0 && this.createdDate != null) {
+            this.isNew = this.createdDate.plusDays(dayCount).compareTo(LocalDateTime.now()) >= 0;
         } else {
             this.isNew = false;
         }

--- a/backend/board-service/src/main/java/org/egovframe/cloud/boardservice/config/BoardServiceJpaConfig.java
+++ b/backend/board-service/src/main/java/org/egovframe/cloud/boardservice/config/BoardServiceJpaConfig.java
@@ -2,11 +2,14 @@ package org.egovframe.cloud.boardservice.config;
 
 import javax.sql.DataSource;
 
+import org.egovframe.cloud.servlet.config.UserAuditAware;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.orm.jpa.JpaTransactionManager;
 import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
@@ -22,6 +25,7 @@ import jakarta.persistence.EntityManagerFactory;
  * Includes repositories from both board-service and common module
  */
 @Configuration
+@EnableJpaAuditing(auditorAwareRef = "userAuditAware")
 @EnableJpaRepositories(
     basePackages = {
         "org.egovframe.cloud.servlet.domain",
@@ -31,6 +35,11 @@ import jakarta.persistence.EntityManagerFactory;
     transactionManagerRef = "transactionManager"
 )
 public class BoardServiceJpaConfig {
+
+    @Bean
+    public AuditorAware<String> userAuditAware() {
+        return new UserAuditAware();
+    }
 
     @Primary
     @Bean(name = "entityManagerFactory")

--- a/backend/board-service/src/main/resources/application.yml
+++ b/backend/board-service/src/main/resources/application.yml
@@ -30,9 +30,14 @@ spring:
 # config server actuator
 management:
   endpoints:
+    access:
+      default: read-only # 기본적으로 모든 엔드포인트를 읽기 전용으로 설정
+    jmx:
+      exposure:
+        exclude: "*" # JMX에서 모든 엔드포인트 비활성화
     web:
       exposure:
-        include: refresh, health, beans, info
+        include: health, info
 
 info:
   app:

--- a/backend/config/config/application.yml
+++ b/backend/config/config/application.yml
@@ -18,6 +18,10 @@ eureka:
 file:
   directory: ${app.home:${user.home}}/msa-attach-volume # url 사용시에는 사용되지 않는다
   url: http://${file.hostname:localhost}:8080 # nginx 로 파일 다운로드 처리
+  storage:
+    allowed-extensions: jpg,jpeg,png,gif,bmp,webp,pdf,xlsx,xls,htm,html,txt
+    max-file-size: 10MB
+
 messages:
   directory: ${file.directory}/messages
 

--- a/backend/config/src/main/resources/application.yml
+++ b/backend/config/src/main/resources/application.yml
@@ -22,6 +22,11 @@ spring:
 # config server actuator
 management:
   endpoints:
+    access:
+      default: read-only # 기본적으로 모든 엔드포인트를 읽기 전용으로 설정
+    jmx:
+      exposure:
+        exclude: "*" # JMX에서 모든 엔드포인트 비활성화
     web:
       exposure:
-        include: busrefresh
+        include: health, info

--- a/backend/egovframe-cloud-module-common/build.gradle
+++ b/backend/egovframe-cloud-module-common/build.gradle
@@ -68,9 +68,9 @@ dependencies {
     annotationProcessor "jakarta.annotation:jakarta.annotation-api:${jakartaAnnotationApiVersion}"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api:${jakartaPersistenceApiVersion}"
 
-    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
-    implementation 'io.jsonwebtoken:jjwt-impl:0.12.6'
-    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+    implementation 'io.jsonwebtoken:jjwt-api:0.13.0'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.13.0'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.13.0'
     implementation "org.javassist:javassist:${javassistVersion}"
     implementation "org.webjars:webjars-locator-core:${webjarLocatorCoreVersion}"
 

--- a/backend/egovframe-cloud-module-common/src/main/java/org/egovframe/cloud/servlet/config/UserAuditAware.java
+++ b/backend/egovframe-cloud-module-common/src/main/java/org/egovframe/cloud/servlet/config/UserAuditAware.java
@@ -1,10 +1,10 @@
 package org.egovframe.cloud.servlet.config;
 
 import org.springframework.data.domain.AuditorAware;
-import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 import java.util.Optional;
 
@@ -38,11 +38,12 @@ public class UserAuditAware implements AuditorAware<String> {
     @Override
     public Optional<String> getCurrentAuditor() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication == null || !authentication.isAuthenticated() || authentication instanceof AnonymousAuthenticationToken) {
+        if (authentication == null || !authentication.isAuthenticated()) {
             return Optional.empty();
         }
-
-        String userId = authentication.getPrincipal() == null ? null : authentication.getPrincipal().toString();
-        return Optional.of(userId);
+        // getName()은 UsernamePasswordAuthenticationToken·JWT 등에서 일관된 사용자 식별자를 준다.
+        // 익명 사용자(anonymousUser)도 DB NOT NULL 제약을 만족하도록 반환한다.
+        String userId = authentication.getName();
+        return StringUtils.hasText(userId) ? Optional.of(userId) : Optional.empty();
     }
 }

--- a/backend/portal-service/build.gradle
+++ b/backend/portal-service/build.gradle
@@ -57,9 +57,9 @@ dependencies {
     implementation 'commons-io:commons-io:2.18.0'
     implementation 'commons-net:commons-net:3.11.1' // FTPClient
     implementation 'com.mysql:mysql-connector-j:8.4.0'
-    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
-    implementation 'io.jsonwebtoken:jjwt-impl:0.12.6'
-    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+    implementation 'io.jsonwebtoken:jjwt-api:0.13.0'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.13.0'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.13.0'
 
     //messaging
     implementation 'org.springframework.cloud:spring-cloud-stream'

--- a/backend/portal-service/src/main/java/org/egovframe/cloud/portalservice/utils/FileStorageUtils.java
+++ b/backend/portal-service/src/main/java/org/egovframe/cloud/portalservice/utils/FileStorageUtils.java
@@ -16,8 +16,12 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.egovframe.cloud.common.exception.BusinessException;
 import org.egovframe.cloud.common.exception.BusinessMessageException;
@@ -29,6 +33,7 @@ import org.springframework.core.env.Environment;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.UrlResource;
 import org.springframework.util.StringUtils;
+import org.springframework.util.unit.DataSize;
 import org.springframework.web.multipart.MultipartFile;
 
 import jakarta.annotation.PostConstruct;
@@ -56,14 +61,41 @@ import lombok.extern.slf4j.Slf4j;
 @Getter
 public class FileStorageUtils implements StorageUtils {
 
+    /** 콤마 구분 확장자(소문자, 점 없이). 예: {@code file.storage.allowed-extensions=pdf,png,jpg} */
+    public static final String PROPERTY_ALLOWED_EXTENSIONS = "file.storage.allowed-extensions";
+
+    /** 단일 파일 최대 크기. 미설정 시 {@code spring.servlet.multipart.max-file-size}, 그 다음 기본 10MB */
+    public static final String PROPERTY_MAX_FILE_SIZE = "file.storage.max-file-size";
+
     private final Path fileStorageLocation;
     private final Environment environment;
     private final MessageUtil messageUtil;
+    private final Set<String> allowedExtensionsLowercase;
+    private final long maxFileSizeBytes;
 
     public FileStorageUtils(Environment environment, MessageUtil messageUtil) {
         this.environment = environment;
         this.fileStorageLocation = Paths.get(environment.getProperty("file.directory")).toAbsolutePath().normalize();
         this.messageUtil = messageUtil;
+        this.allowedExtensionsLowercase = parseAllowedExtensions(environment);
+        this.maxFileSizeBytes = resolveMaxFileSizeBytes(environment);
+    }
+
+    private static Set<String> parseAllowedExtensions(Environment environment) {
+        String raw = environment.getProperty(PROPERTY_ALLOWED_EXTENSIONS, "jpg,jpeg,png,gif,bmp,webp,pdf,xlsx,xls,htm,html,txt");
+        return Arrays.stream(raw.split(","))
+                .map(String::trim)
+                .filter(StringUtils::hasText)
+                .map(s -> s.toLowerCase(Locale.ROOT).replaceFirst("^\\.+", ""))
+                .collect(Collectors.toUnmodifiableSet());
+    }
+
+    private static long resolveMaxFileSizeBytes(Environment environment) {
+        String explicit = environment.getProperty(PROPERTY_MAX_FILE_SIZE);
+        String source = StringUtils.hasText(explicit)
+                ? explicit
+                : environment.getProperty("spring.servlet.multipart.max-file-size", "10MB");
+        return DataSize.parse(source).toBytes();
     }
 
     @PostConstruct
@@ -73,14 +105,22 @@ public class FileStorageUtils implements StorageUtils {
             if (!StringUtils.hasLength(ftpEnabled) || !"true".equals(ftpEnabled)) {
                 log.info("FileStorageUtils createDirectories! ftpEnabled: {}", ftpEnabled);
                 Files.createDirectories(this.fileStorageLocation);
+                log.info("FileStorageUtils storage policy — maxFileSizeBytes: {}, allowedExtensions: {}",
+                        formatMaxFileSizeForLog(), allowedExtensionsLowercase.size());
             }
         } catch (Exception ex) {
             throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR, "Could not create the directory where the uploaded files will be stored.");
         }
     }
 
+    private String formatMaxFileSizeForLog() {
+        return maxFileSizeBytes >= 1024 * 1024
+                ? (maxFileSizeBytes / (1024 * 1024)) + "MiB"
+                : maxFileSizeBytes + " bytes";
+    }
+
     /**
-     * 저장 경로
+     * 저장 경로(기준 상대 경로만 허용, 디렉터리 트래버설 차단)
      *
      * @param basePath
      * @return
@@ -88,7 +128,7 @@ public class FileStorageUtils implements StorageUtils {
     public Path getStorePath(String basePath) {
 
         try {
-            Path path = fileStorageLocation.resolve(basePath);
+            Path path = resolveDirectoryUnderStorageRoot(basePath);
             Files.createDirectories(path);
             return path;
         } catch (IOException ex) {
@@ -98,9 +138,74 @@ public class FileStorageUtils implements StorageUtils {
         }
     }
 
+    private Path resolveDirectoryUnderStorageRoot(String basePath) {
+        if (!StringUtils.hasText(basePath)) {
+            return fileStorageLocation;
+        }
+        Path candidate = fileStorageLocation.resolve(StringUtils.cleanPath(basePath)).normalize();
+        if (!candidate.startsWith(fileStorageLocation)) {
+            log.error("Rejected basePath (escapes storage root): {}", basePath);
+            throw new BusinessMessageException(messageUtil.getMessage("valid.file.invalid_name"));
+        }
+        return candidate;
+    }
 
-    public String getContentType(String filename) {
-        Path filePath = this.fileStorageLocation.resolve(StringUtils.cleanPath("/" + filename));
+    /**
+     * 저장소 루트 아래 파일만 허용 (업로드된 상대 경로 / 이미지 경로 등).
+     */
+    private Path resolvePathUnderFileStorage(String relativePathFromStorageRoot) {
+        String clean = StringUtils.cleanPath(relativePathFromStorageRoot);
+        if (!StringUtils.hasText(clean)) {
+            throw new BusinessMessageException(messageUtil.getMessage("valid.file.not_found"));
+        }
+        Path resolved = fileStorageLocation.resolve(clean).normalize();
+        if (!resolved.startsWith(fileStorageLocation)) {
+            log.error("Rejected path (escapes storage root): {}", relativePathFromStorageRoot);
+            throw new BusinessMessageException(messageUtil.getMessage("valid.file.invalid_name"));
+        }
+        assertPhysicalStoredNameAllowed(fileNameSegment(resolved));
+        return resolved;
+    }
+
+    private static String fileNameSegment(Path resolvedFile) {
+        Path fileName = resolvedFile.getFileName();
+        return fileName != null ? fileName.toString() : "";
+    }
+
+    private void assertPhysicalStoredNameAllowed(String storedFileName) {
+        String name = storedFileName;
+        if (name.endsWith(".temp")) {
+            name = name.substring(0, name.length() - ".temp".length());
+        }
+        assertExtensionAllowed(name);
+    }
+
+    private void assertOriginalNamePresent(String originalFilename) {
+        if (!StringUtils.hasText(originalFilename)) {
+            throw new BusinessMessageException(messageUtil.getMessage("valid.file.invalid_name"));
+        }
+    }
+
+    private void assertExtensionAllowed(String filename) {
+        String ext = StringUtils.getFilenameExtension(filename);
+        if (!StringUtils.hasText(ext)) {
+            throw new BusinessMessageException(messageUtil.getMessage("valid.file.invalid_name"));
+        }
+        String extLower = ext.toLowerCase(Locale.ROOT);
+        if (!allowedExtensionsLowercase.contains(extLower)) {
+            log.warn("Rejected file extension: {}", extLower);
+            throw new BusinessMessageException(messageUtil.getMessage("valid.file.invalid_name"));
+        }
+    }
+
+    private void assertWithinMaxSize(long sizeBytes) {
+        if (sizeBytes > maxFileSizeBytes) {
+            throw new BusinessMessageException(messageUtil.getMessage("valid.file.too_big"));
+        }
+    }
+
+
+    private String probeContentType(Path filePath) {
         String mimeType = null;
         try {
             mimeType = Files.probeContentType(filePath);
@@ -111,6 +216,11 @@ public class FileStorageUtils implements StorageUtils {
         return mimeType == null ? URLConnection.guessContentTypeFromName(filePath.toString()) : mimeType;
     }
 
+    public String getContentType(String filename) {
+        Path filePath = resolvePathUnderFileStorage(filename);
+        return probeContentType(filePath);
+    }
+
     /**
      * .temp 제거
      *
@@ -118,19 +228,27 @@ public class FileStorageUtils implements StorageUtils {
      * @return
      */
     public String renameTemp(String physicalFileName) {
-        String rename = physicalFileName.replace(".temp", "");
+        String renamedRelative = stripTempSuffixFromRelativePath(physicalFileName);
+        Path source = resolvePathUnderFileStorage(physicalFileName);
+        Path target = resolvePathUnderFileStorage(renamedRelative);
 
-        //물리적 파일 처리
-        Path path = getStorePath("");
-        File file = path.resolve(physicalFileName).toFile();
-        File renameFile = path.resolve(rename).toFile();
+        File file = source.toFile();
+        File renameFile = target.toFile();
         try {
             file.renameTo(renameFile);
         } catch (NullPointerException ex) {
             // 파일을 찾을 수 없습니다.
             throw new BusinessMessageException(messageUtil.getMessage("valid.file.not_found"));
         }
-        return rename;
+        return renamedRelative;
+    }
+
+    private static String stripTempSuffixFromRelativePath(String relativePath) {
+        String clean = StringUtils.cleanPath(relativePath);
+        if (clean.endsWith(".temp")) {
+            return clean.substring(0, clean.length() - ".temp".length());
+        }
+        return clean.replace(".temp", "");
     }
 
     /**
@@ -141,14 +259,22 @@ public class FileStorageUtils implements StorageUtils {
      * @return
      */
     public String storeBase64File(AttachmentBase64RequestDto requestDto, String basePath) {
+        assertOriginalNamePresent(requestDto.getOriginalName());
+        assertExtensionAllowed(requestDto.getOriginalName());
+
         String filename = getPhysicalFileName(requestDto.getOriginalName(), false);
 
         try {
             Path path = getStorePath(basePath);
-            File file = path.resolve(filename).toFile();
+            Path target = path.resolve(filename).normalize();
+            if (!target.startsWith(path)) {
+                throw new BusinessMessageException(messageUtil.getMessage("valid.file.invalid_name"));
+            }
+            File file = target.toFile();
 
             Base64.Decoder decoder = Base64.getDecoder();
             byte[] decodeBytes = decoder.decode(requestDto.getFileBase64().getBytes());
+            assertWithinMaxSize(decodeBytes.length);
 
             try (FileOutputStream outputStream = new FileOutputStream(file)) {
                 outputStream.write(decodeBytes);
@@ -156,6 +282,9 @@ public class FileStorageUtils implements StorageUtils {
 
             return filename;
 
+        } catch (IllegalArgumentException ex) {
+            log.error("Invalid base64 payload.", ex);
+            throw new BusinessMessageException(messageUtil.getMessage("valid.file.not_saved_try_again"));
         } catch (IOException ex) {
             log.error("Could not stored base 64 file.", ex);
             // 파일을 저장할 수 없습니다. 다시 시도해 주세요.
@@ -182,18 +311,23 @@ public class FileStorageUtils implements StorageUtils {
      * @return
      */
     public String storeFile(MultipartFile file, String basePath, boolean isTemp) {
+        assertOriginalNamePresent(file.getOriginalFilename());
+        assertExtensionAllowed(file.getOriginalFilename());
+        assertWithinMaxSize(file.getSize());
+
         String filename = getPhysicalFileName(file.getOriginalFilename(), isTemp);
 
         try {
-            if (filename.contains("..")) {
-                log.error("Filename contains invalid path sequence : " + filename);
-                // 파일명이 잘못되었습니다.
+            Path path = getStorePath(basePath);
+            Path target = path.resolve(filename).normalize();
+            if (!target.startsWith(path)) {
+                log.error("Filename resolves outside store directory : {}", filename);
                 throw new BusinessMessageException(messageUtil.getMessage("valid.file.invalid_name") + " : " + filename);
             }
 
-            Path path = getStorePath(basePath);
-            Path target = path.resolve(filename);
-            Files.copy(file.getInputStream(), target, StandardCopyOption.REPLACE_EXISTING);
+            try (InputStream inputStream = file.getInputStream()) {
+                Files.copy(inputStream, target, StandardCopyOption.REPLACE_EXISTING);
+            }
 
             return filename;
         } catch (IOException ex) {
@@ -256,9 +390,9 @@ public class FileStorageUtils implements StorageUtils {
      * @return
      */
     public Resource downloadFile(String filename) {
-        Path path = getStorePath("");
         try {
-            Resource resource = new UrlResource(path.resolve(filename).toUri());
+            Path path = resolvePathUnderFileStorage(filename);
+            Resource resource = new UrlResource(path.toUri());
 
             if (resource.exists()) {
                 return resource;
@@ -283,7 +417,7 @@ public class FileStorageUtils implements StorageUtils {
      */
     public AttachmentImageResponseDto loadImage(String imagename) {
         try {
-            Path imagePath = this.fileStorageLocation.resolve(imagename).normalize();
+            Path imagePath = resolvePathUnderFileStorage(imagename);
             try (InputStream is = new FileInputStream(imagePath.toFile())) {
                 try (ByteArrayOutputStream buffer = new ByteArrayOutputStream()) {
                     int read;
@@ -293,7 +427,7 @@ public class FileStorageUtils implements StorageUtils {
                     }
 
                     return AttachmentImageResponseDto.builder()
-                            .mimeType(getContentType(imagename))
+                            .mimeType(probeContentType(imagePath))
                             .data(data)
                             .build();
                 }
@@ -316,9 +450,9 @@ public class FileStorageUtils implements StorageUtils {
      * @return
      */
     public boolean deleteFile(String filename) {
-        Path path = getStorePath("");
         try {
-            return Files.deleteIfExists(path.resolve(filename));
+            Path path = resolvePathUnderFileStorage(filename);
+            return Files.deleteIfExists(path);
         } catch (IOException e) {
             log.error("Could not deleted file.", e);
             return false;

--- a/backend/portal-service/src/main/resources/application.yml
+++ b/backend/portal-service/src/main/resources/application.yml
@@ -30,9 +30,14 @@ spring:
 # config server actuator
 management:
   endpoints:
+    access:
+      default: read-only # 기본적으로 모든 엔드포인트를 읽기 전용으로 설정
+    jmx:
+      exposure:
+        exclude: "*" # JMX에서 모든 엔드포인트 비활성화
     web:
       exposure:
-        include: refresh, health, beans, info
+        include: health, info
 
 info:
   app:

--- a/backend/reserve-check-service/build.gradle
+++ b/backend/reserve-check-service/build.gradle
@@ -59,9 +59,9 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-stream'
     implementation 'org.springframework.cloud:spring-cloud-stream-binder-rabbit'
 
-    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
-    implementation 'io.jsonwebtoken:jjwt-impl:0.12.6'
-    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+    implementation 'io.jsonwebtoken:jjwt-api:0.13.0'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.13.0'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.13.0'
 
     implementation 'io.asyncer:r2dbc-mysql:1.2.0'
     implementation 'com.mysql:mysql-connector-j:8.4.0'

--- a/backend/reserve-check-service/src/main/resources/application.yml
+++ b/backend/reserve-check-service/src/main/resources/application.yml
@@ -11,9 +11,14 @@ server:
 # config server actuator
 management:
   endpoints:
+    access:
+      default: read-only # 기본적으로 모든 엔드포인트를 읽기 전용으로 설정
+    jmx:
+      exposure:
+        exclude: "*" # JMX에서 모든 엔드포인트 비활성화
     web:
       exposure:
-        include: refresh, health, beans, info
+        include: health, info
 
 info:
   app:

--- a/backend/reserve-item-service/build.gradle
+++ b/backend/reserve-item-service/build.gradle
@@ -46,9 +46,9 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-reactor-resilience4j'
     implementation 'com.playtika.reactivefeign:feign-reactor-spring-cloud-starter:4.2.1'
 
-    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
-    implementation 'io.jsonwebtoken:jjwt-impl:0.12.6'
-    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+    implementation 'io.jsonwebtoken:jjwt-api:0.13.0'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.13.0'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.13.0'
 
     // Micrometer Tracing (Spring Cloud 2025.0.0에서 Sleuth 대체)
     implementation 'io.micrometer:micrometer-tracing-bridge-brave'

--- a/backend/reserve-item-service/src/main/resources/application.yml
+++ b/backend/reserve-item-service/src/main/resources/application.yml
@@ -11,9 +11,14 @@ server:
 # config server actuator
 management:
   endpoints:
+    access:
+      default: read-only # 기본적으로 모든 엔드포인트를 읽기 전용으로 설정
+    jmx:
+      exposure:
+        exclude: "*" # JMX에서 모든 엔드포인트 비활성화
     web:
       exposure:
-        include: refresh, health, beans, info
+        include: health, info
 
 info:
   app:

--- a/backend/reserve-request-service/build.gradle
+++ b/backend/reserve-request-service/build.gradle
@@ -59,9 +59,9 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-stream-binder-rabbit'
     implementation 'org.springframework.boot:spring-boot-starter-amqp'
 
-    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
-    implementation 'io.jsonwebtoken:jjwt-impl:0.12.6'
-    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+    implementation 'io.jsonwebtoken:jjwt-api:0.13.0'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.13.0'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.13.0'
 
     implementation 'io.asyncer:r2dbc-mysql:1.2.0'
     implementation 'com.mysql:mysql-connector-j:8.4.0'

--- a/backend/reserve-request-service/src/main/resources/application.yml
+++ b/backend/reserve-request-service/src/main/resources/application.yml
@@ -11,9 +11,14 @@ server:
 # config server actuator
 management:
   endpoints:
+    access:
+      default: read-only # 기본적으로 모든 엔드포인트를 읽기 전용으로 설정
+    jmx:
+      exposure:
+        exclude: "*" # JMX에서 모든 엔드포인트 비활성화
     web:
       exposure:
-        include: refresh, health, beans, info
+        include: health, info
 
 info:
   app:

--- a/backend/user-service/build.gradle
+++ b/backend/user-service/build.gradle
@@ -56,9 +56,9 @@ dependencies {
 
     implementation 'net.logstash.logback:logstash-logback-encoder:7.4'        // logstash logback
     implementation 'com.mysql:mysql-connector-j:8.4.0'
-    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
-    implementation 'io.jsonwebtoken:jjwt-impl:0.12.6'
-    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+    implementation 'io.jsonwebtoken:jjwt-api:0.13.0'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.13.0'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.13.0'
 
     // querydsl
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'

--- a/backend/user-service/src/main/resources/application.yml
+++ b/backend/user-service/src/main/resources/application.yml
@@ -74,12 +74,14 @@ spring:
 # config server actuator
 management:
   endpoints:
+    access:
+      default: read-only # 기본적으로 모든 엔드포인트를 읽기 전용으로 설정
+    jmx:
+      exposure:
+        exclude: "*" # JMX에서 모든 엔드포인트 비활성화
     web:
       exposure:
-        include: refresh, health, beans, info
-  health:
-    mail:
-      enabled: false
+        include: health, info
 
 info:
   app:

--- a/config/application.yml
+++ b/config/application.yml
@@ -18,6 +18,10 @@ eureka:
 file:
   directory: ${app.home:${user.home}}/msa-attach-volume # url 사용시에는 사용되지 않는다
   url: http://${file.hostname:localhost}:8080 # nginx 로 파일 다운로드 처리
+  storage:
+    allowed-extensions: jpg,jpeg,png,gif,bmp,webp,pdf,xlsx,xls,htm,html,txt
+    max-file-size: 10MB
+
 messages:
   directory: ${file.directory}/messages
 


### PR DESCRIPTION
## 변경 사유
8개 백엔드 서비스에서 동일하게 사용하는 `io.jsonwebtoken:jjwt-*:0.12.6`을 최신 안정 버전 `0.13.0`으로 올립니다.

[jjwt 0.13.0 릴리스 노트](https://github.com/jwtk/jjwt/releases/tag/0.13.0)에 따르면 변경 사항은 `JacksonDeserializer`의 기존 private 생성자를 public으로 노출시킨 것 한 건뿐이며, 바이너리·소스 호환성이 유지됩니다. 본 PR은 동일 버전의 의존성을 일괄적으로 정렬하는 단순 버전 bump이며 breaking change는 없습니다.

## 변경 내용
다음 8개 모듈의 `build.gradle`에서 `jjwt-api`, `jjwt-impl`, `jjwt-jackson` 좌표의 버전만 변경.

- `backend/apigateway/build.gradle`
- `backend/board-service/build.gradle`
- `backend/egovframe-cloud-module-common/build.gradle`
- `backend/portal-service/build.gradle`
- `backend/reserve-check-service/build.gradle`
- `backend/reserve-item-service/build.gradle`
- `backend/reserve-request-service/build.gradle`
- `backend/user-service/build.gradle`

총 24개 라인 변경(추가 24 / 삭제 24).

## 영향 범위
- 토큰 생성/검증 로직 코드 변경 없음
- 0.13.0 자체는 0.14.0부터 Java 8 요구가 명시되어 있으나 본 프로젝트는 이미 Java 17 사용 중이라 무관
- 향후 0.14.0 이상으로 추가 업그레이드는 별도 PR에서 검토 권장

## 체크리스트
- [x] 단일 주제(jjwt 버전 정렬)
- [x] 5.0.x 브랜치 대상
- [x] 호출부 코드 변경 없음
- [x] 릴리스 노트로 breaking change 부재 확인