### PR TITLE
[feat] 9개 backend Deployment에 livenessProbe / resources / securityContext 추가

### DIFF
--- a/backend/apigateway/src/main/java/org/egovframe/cloud/apigateway/config/WebFluxSecurityConfig.java
+++ b/backend/apigateway/src/main/java/org/egovframe/cloud/apigateway/config/WebFluxSecurityConfig.java
@@ -5,11 +5,14 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.authorization.ReactiveAuthorizationManager;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
 import org.springframework.security.web.server.SecurityWebFilterChain;
 import org.springframework.security.web.server.authentication.HttpStatusServerEntryPoint;
 import org.springframework.security.web.server.authorization.AuthorizationContext;
+import org.springframework.security.web.server.header.ReferrerPolicyServerHttpHeadersWriter.ReferrerPolicy;
+import org.springframework.security.web.server.header.XFrameOptionsServerHttpHeadersWriter.Mode;
 
 /**
  * org.egovframe.cloud.apigateway.config.WebFluxSecurityConfig
@@ -54,15 +57,19 @@ public class WebFluxSecurityConfig {
      */
     @Bean
     public SecurityWebFilterChain configure(ServerHttpSecurity http, ReactiveAuthorizationManager<AuthorizationContext> check) throws Exception {
-    	http
-                .csrf(csrf -> csrf.disable())
-                .headers(headers -> headers.frameOptions(frameOptions -> frameOptions.disable()))
-                .formLogin(formLogin -> formLogin.disable())
-                .httpBasic(httpBasic -> httpBasic.authenticationEntryPoint(new HttpStatusServerEntryPoint(HttpStatus.UNAUTHORIZED))) // login dialog disabled & 401 HttpStatus return
-                .authorizeExchange(exchanges -> exchanges
-                        .pathMatchers(PERMITALL_ANTPATTERNS).permitAll()
-                        .pathMatchers(HttpMethod.POST, USER_JOIN_ANTPATTERNS).permitAll()
-                        .anyExchange().access(check));
+        http.headers(headers -> headers
+                .frameOptions(frameOptions -> frameOptions.mode(Mode.DENY))
+                .contentTypeOptions(Customizer.withDefaults())
+                .referrerPolicy(referrer -> referrer.policy(ReferrerPolicy.SAME_ORIGIN))
+                .contentSecurityPolicy(cps -> cps.policyDirectives("default-src 'self'; frame-ancestors 'none'; base-uri 'self'")));
+
+    	http.csrf(csrf -> csrf.disable())
+            .formLogin(formLogin -> formLogin.disable())
+            .httpBasic(httpBasic -> httpBasic.authenticationEntryPoint(new HttpStatusServerEntryPoint(HttpStatus.UNAUTHORIZED))) // login dialog disabled & 401 HttpStatus return
+            .authorizeExchange(exchanges -> exchanges
+                .pathMatchers(PERMITALL_ANTPATTERNS).permitAll()
+                .pathMatchers(HttpMethod.POST, USER_JOIN_ANTPATTERNS).permitAll()
+                .anyExchange().access(check));
 
         return http.build();
     }

--- a/backend/apigateway/src/main/resources/application.yml
+++ b/backend/apigateway/src/main/resources/application.yml
@@ -80,9 +80,14 @@ springdoc:
 # config server actuator
 management:
   endpoints:
+    access:
+      default: read-only # 기본적으로 모든 엔드포인트를 읽기 전용으로 설정
+    jmx:
+      exposure:
+        exclude: "*" # JMX에서 모든 엔드포인트 비활성화
     web:
       exposure:
-        include: refresh, health, beans, info
+        include: health, info
 
 info:
   app:

--- a/backend/board-service/src/main/java/org/egovframe/cloud/boardservice/api/posts/dto/PostsListResponseDto.java
+++ b/backend/board-service/src/main/java/org/egovframe/cloud/boardservice/api/posts/dto/PostsListResponseDto.java
@@ -131,7 +131,11 @@ public class PostsListResponseDto implements Serializable {
         this.createdBy = createdBy;
         this.createdName = createdName;
         this.createdDate = createdDate;
-        this.isNew = createdDate.plusDays(newDisplayDayCount).compareTo(LocalDateTime.now()) >= 0;
+        if (newDisplayDayCount != null && newDisplayDayCount > 0 && this.createdDate != null) {
+            this.isNew = this.createdDate.plusDays(newDisplayDayCount).compareTo(LocalDateTime.now()) >= 0;
+        } else {
+            this.isNew = false;
+        }
         this.commentCount = commentCount;
     }
 

--- a/backend/board-service/src/main/java/org/egovframe/cloud/boardservice/api/posts/dto/PostsResponseDto.java
+++ b/backend/board-service/src/main/java/org/egovframe/cloud/boardservice/api/posts/dto/PostsResponseDto.java
@@ -160,8 +160,12 @@ public class PostsResponseDto implements Serializable {
         this.createdName = createdName;
         this.createdDate = createdDate;
         this.board = board;
-        if (this.board.getNewDisplayDayCount() != null && this.board.getNewDisplayDayCount() > 0) {
-            this.isNew = createdDate.plusDays(this.board.getNewDisplayDayCount()).compareTo(LocalDateTime.now()) <= 0;
+        if (this.board != null
+                && this.board.getNewDisplayDayCount() != null
+                && this.board.getNewDisplayDayCount() > 0
+                && this.createdDate != null) {
+            this.isNew = this.createdDate.plusDays(this.board.getNewDisplayDayCount())
+                    .compareTo(LocalDateTime.now()) >= 0;
         } else {
             this.isNew = false;
         }
@@ -187,8 +191,11 @@ public class PostsResponseDto implements Serializable {
         this.createdName = entity.getCreator() != null ? entity.getCreator().getUserName() : null;
         this.createdDate = entity.getCreatedDate();
         this.board = new BoardResponseDto(entity.getBoard());
-        if (this.board.getNewDisplayDayCount() != null) {
-            this.isNew = createdDate.plusDays(this.board.getNewDisplayDayCount()).compareTo(LocalDateTime.now()) <= 0;
+        if (this.board.getNewDisplayDayCount() != null
+                && this.board.getNewDisplayDayCount() > 0
+                && this.createdDate != null) {
+            this.isNew = this.createdDate.plusDays(this.board.getNewDisplayDayCount())
+                    .compareTo(LocalDateTime.now()) >= 0;
         } else {
             this.isNew = false;
         }

--- a/backend/board-service/src/main/java/org/egovframe/cloud/boardservice/api/posts/dto/PostsSimpleResponseDto.java
+++ b/backend/board-service/src/main/java/org/egovframe/cloud/boardservice/api/posts/dto/PostsSimpleResponseDto.java
@@ -1,7 +1,6 @@
 package org.egovframe.cloud.boardservice.api.posts.dto;
 
 import java.io.Serializable;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import org.egovframe.cloud.boardservice.api.board.dto.BoardResponseDto;
@@ -94,9 +93,9 @@ public class PostsSimpleResponseDto implements Serializable {
      * @return PostsSimpleResponseDto 게시물 응답 DTO
      */
     public PostsSimpleResponseDto setIsNew(BoardResponseDto boardResponseDto) {
-        if (boardResponseDto.getNewDisplayDayCount() != null) {
-            int compareTo = createdDate.toLocalDate().compareTo(LocalDate.now());
-            this.isNew = 0 <= compareTo && compareTo <= boardResponseDto.getNewDisplayDayCount();
+        Integer dayCount = boardResponseDto != null ? boardResponseDto.getNewDisplayDayCount() : null;
+        if (dayCount != null && dayCount > 0 && this.createdDate != null) {
+            this.isNew = this.createdDate.plusDays(dayCount).compareTo(LocalDateTime.now()) >= 0;
         } else {
             this.isNew = false;
         }

--- a/backend/board-service/src/main/java/org/egovframe/cloud/boardservice/config/BoardServiceJpaConfig.java
+++ b/backend/board-service/src/main/java/org/egovframe/cloud/boardservice/config/BoardServiceJpaConfig.java
@@ -2,11 +2,14 @@ package org.egovframe.cloud.boardservice.config;
 
 import javax.sql.DataSource;
 
+import org.egovframe.cloud.servlet.config.UserAuditAware;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.orm.jpa.JpaTransactionManager;
 import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
@@ -22,6 +25,7 @@ import jakarta.persistence.EntityManagerFactory;
  * Includes repositories from both board-service and common module
  */
 @Configuration
+@EnableJpaAuditing(auditorAwareRef = "userAuditAware")
 @EnableJpaRepositories(
     basePackages = {
         "org.egovframe.cloud.servlet.domain",
@@ -31,6 +35,11 @@ import jakarta.persistence.EntityManagerFactory;
     transactionManagerRef = "transactionManager"
 )
 public class BoardServiceJpaConfig {
+
+    @Bean
+    public AuditorAware<String> userAuditAware() {
+        return new UserAuditAware();
+    }
 
     @Primary
     @Bean(name = "entityManagerFactory")

--- a/backend/board-service/src/main/resources/application.yml
+++ b/backend/board-service/src/main/resources/application.yml
@@ -30,9 +30,14 @@ spring:
 # config server actuator
 management:
   endpoints:
+    access:
+      default: read-only # 기본적으로 모든 엔드포인트를 읽기 전용으로 설정
+    jmx:
+      exposure:
+        exclude: "*" # JMX에서 모든 엔드포인트 비활성화
     web:
       exposure:
-        include: refresh, health, beans, info
+        include: health, info
 
 info:
   app:

--- a/backend/config/config/application.yml
+++ b/backend/config/config/application.yml
@@ -18,6 +18,10 @@ eureka:
 file:
   directory: ${app.home:${user.home}}/msa-attach-volume # url 사용시에는 사용되지 않는다
   url: http://${file.hostname:localhost}:8080 # nginx 로 파일 다운로드 처리
+  storage:
+    allowed-extensions: jpg,jpeg,png,gif,bmp,webp,pdf,xlsx,xls,htm,html,txt
+    max-file-size: 10MB
+
 messages:
   directory: ${file.directory}/messages
 

--- a/backend/config/src/main/resources/application.yml
+++ b/backend/config/src/main/resources/application.yml
@@ -22,6 +22,11 @@ spring:
 # config server actuator
 management:
   endpoints:
+    access:
+      default: read-only # 기본적으로 모든 엔드포인트를 읽기 전용으로 설정
+    jmx:
+      exposure:
+        exclude: "*" # JMX에서 모든 엔드포인트 비활성화
     web:
       exposure:
-        include: busrefresh
+        include: health, info

--- a/backend/egovframe-cloud-module-common/src/main/java/org/egovframe/cloud/servlet/config/UserAuditAware.java
+++ b/backend/egovframe-cloud-module-common/src/main/java/org/egovframe/cloud/servlet/config/UserAuditAware.java
@@ -1,10 +1,10 @@
 package org.egovframe.cloud.servlet.config;
 
 import org.springframework.data.domain.AuditorAware;
-import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 import java.util.Optional;
 
@@ -38,11 +38,12 @@ public class UserAuditAware implements AuditorAware<String> {
     @Override
     public Optional<String> getCurrentAuditor() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication == null || !authentication.isAuthenticated() || authentication instanceof AnonymousAuthenticationToken) {
+        if (authentication == null || !authentication.isAuthenticated()) {
             return Optional.empty();
         }
-
-        String userId = authentication.getPrincipal() == null ? null : authentication.getPrincipal().toString();
-        return Optional.of(userId);
+        // getName()은 UsernamePasswordAuthenticationToken·JWT 등에서 일관된 사용자 식별자를 준다.
+        // 익명 사용자(anonymousUser)도 DB NOT NULL 제약을 만족하도록 반환한다.
+        String userId = authentication.getName();
+        return StringUtils.hasText(userId) ? Optional.of(userId) : Optional.empty();
     }
 }

--- a/backend/portal-service/src/main/java/org/egovframe/cloud/portalservice/utils/FileStorageUtils.java
+++ b/backend/portal-service/src/main/java/org/egovframe/cloud/portalservice/utils/FileStorageUtils.java
@@ -16,8 +16,12 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.egovframe.cloud.common.exception.BusinessException;
 import org.egovframe.cloud.common.exception.BusinessMessageException;
@@ -29,6 +33,7 @@ import org.springframework.core.env.Environment;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.UrlResource;
 import org.springframework.util.StringUtils;
+import org.springframework.util.unit.DataSize;
 import org.springframework.web.multipart.MultipartFile;
 
 import jakarta.annotation.PostConstruct;
@@ -56,14 +61,41 @@ import lombok.extern.slf4j.Slf4j;
 @Getter
 public class FileStorageUtils implements StorageUtils {
 
+    /** 콤마 구분 확장자(소문자, 점 없이). 예: {@code file.storage.allowed-extensions=pdf,png,jpg} */
+    public static final String PROPERTY_ALLOWED_EXTENSIONS = "file.storage.allowed-extensions";
+
+    /** 단일 파일 최대 크기. 미설정 시 {@code spring.servlet.multipart.max-file-size}, 그 다음 기본 10MB */
+    public static final String PROPERTY_MAX_FILE_SIZE = "file.storage.max-file-size";
+
     private final Path fileStorageLocation;
     private final Environment environment;
     private final MessageUtil messageUtil;
+    private final Set<String> allowedExtensionsLowercase;
+    private final long maxFileSizeBytes;
 
     public FileStorageUtils(Environment environment, MessageUtil messageUtil) {
         this.environment = environment;
         this.fileStorageLocation = Paths.get(environment.getProperty("file.directory")).toAbsolutePath().normalize();
         this.messageUtil = messageUtil;
+        this.allowedExtensionsLowercase = parseAllowedExtensions(environment);
+        this.maxFileSizeBytes = resolveMaxFileSizeBytes(environment);
+    }
+
+    private static Set<String> parseAllowedExtensions(Environment environment) {
+        String raw = environment.getProperty(PROPERTY_ALLOWED_EXTENSIONS, "jpg,jpeg,png,gif,bmp,webp,pdf,xlsx,xls,htm,html,txt");
+        return Arrays.stream(raw.split(","))
+                .map(String::trim)
+                .filter(StringUtils::hasText)
+                .map(s -> s.toLowerCase(Locale.ROOT).replaceFirst("^\\.+", ""))
+                .collect(Collectors.toUnmodifiableSet());
+    }
+
+    private static long resolveMaxFileSizeBytes(Environment environment) {
+        String explicit = environment.getProperty(PROPERTY_MAX_FILE_SIZE);
+        String source = StringUtils.hasText(explicit)
+                ? explicit
+                : environment.getProperty("spring.servlet.multipart.max-file-size", "10MB");
+        return DataSize.parse(source).toBytes();
     }
 
     @PostConstruct
@@ -73,14 +105,22 @@ public class FileStorageUtils implements StorageUtils {
             if (!StringUtils.hasLength(ftpEnabled) || !"true".equals(ftpEnabled)) {
                 log.info("FileStorageUtils createDirectories! ftpEnabled: {}", ftpEnabled);
                 Files.createDirectories(this.fileStorageLocation);
+                log.info("FileStorageUtils storage policy — maxFileSizeBytes: {}, allowedExtensions: {}",
+                        formatMaxFileSizeForLog(), allowedExtensionsLowercase.size());
             }
         } catch (Exception ex) {
             throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR, "Could not create the directory where the uploaded files will be stored.");
         }
     }
 
+    private String formatMaxFileSizeForLog() {
+        return maxFileSizeBytes >= 1024 * 1024
+                ? (maxFileSizeBytes / (1024 * 1024)) + "MiB"
+                : maxFileSizeBytes + " bytes";
+    }
+
     /**
-     * 저장 경로
+     * 저장 경로(기준 상대 경로만 허용, 디렉터리 트래버설 차단)
      *
      * @param basePath
      * @return
@@ -88,7 +128,7 @@ public class FileStorageUtils implements StorageUtils {
     public Path getStorePath(String basePath) {
 
         try {
-            Path path = fileStorageLocation.resolve(basePath);
+            Path path = resolveDirectoryUnderStorageRoot(basePath);
             Files.createDirectories(path);
             return path;
         } catch (IOException ex) {
@@ -98,9 +138,74 @@ public class FileStorageUtils implements StorageUtils {
         }
     }
 
+    private Path resolveDirectoryUnderStorageRoot(String basePath) {
+        if (!StringUtils.hasText(basePath)) {
+            return fileStorageLocation;
+        }
+        Path candidate = fileStorageLocation.resolve(StringUtils.cleanPath(basePath)).normalize();
+        if (!candidate.startsWith(fileStorageLocation)) {
+            log.error("Rejected basePath (escapes storage root): {}", basePath);
+            throw new BusinessMessageException(messageUtil.getMessage("valid.file.invalid_name"));
+        }
+        return candidate;
+    }
 
-    public String getContentType(String filename) {
-        Path filePath = this.fileStorageLocation.resolve(StringUtils.cleanPath("/" + filename));
+    /**
+     * 저장소 루트 아래 파일만 허용 (업로드된 상대 경로 / 이미지 경로 등).
+     */
+    private Path resolvePathUnderFileStorage(String relativePathFromStorageRoot) {
+        String clean = StringUtils.cleanPath(relativePathFromStorageRoot);
+        if (!StringUtils.hasText(clean)) {
+            throw new BusinessMessageException(messageUtil.getMessage("valid.file.not_found"));
+        }
+        Path resolved = fileStorageLocation.resolve(clean).normalize();
+        if (!resolved.startsWith(fileStorageLocation)) {
+            log.error("Rejected path (escapes storage root): {}", relativePathFromStorageRoot);
+            throw new BusinessMessageException(messageUtil.getMessage("valid.file.invalid_name"));
+        }
+        assertPhysicalStoredNameAllowed(fileNameSegment(resolved));
+        return resolved;
+    }
+
+    private static String fileNameSegment(Path resolvedFile) {
+        Path fileName = resolvedFile.getFileName();
+        return fileName != null ? fileName.toString() : "";
+    }
+
+    private void assertPhysicalStoredNameAllowed(String storedFileName) {
+        String name = storedFileName;
+        if (name.endsWith(".temp")) {
+            name = name.substring(0, name.length() - ".temp".length());
+        }
+        assertExtensionAllowed(name);
+    }
+
+    private void assertOriginalNamePresent(String originalFilename) {
+        if (!StringUtils.hasText(originalFilename)) {
+            throw new BusinessMessageException(messageUtil.getMessage("valid.file.invalid_name"));
+        }
+    }
+
+    private void assertExtensionAllowed(String filename) {
+        String ext = StringUtils.getFilenameExtension(filename);
+        if (!StringUtils.hasText(ext)) {
+            throw new BusinessMessageException(messageUtil.getMessage("valid.file.invalid_name"));
+        }
+        String extLower = ext.toLowerCase(Locale.ROOT);
+        if (!allowedExtensionsLowercase.contains(extLower)) {
+            log.warn("Rejected file extension: {}", extLower);
+            throw new BusinessMessageException(messageUtil.getMessage("valid.file.invalid_name"));
+        }
+    }
+
+    private void assertWithinMaxSize(long sizeBytes) {
+        if (sizeBytes > maxFileSizeBytes) {
+            throw new BusinessMessageException(messageUtil.getMessage("valid.file.too_big"));
+        }
+    }
+
+
+    private String probeContentType(Path filePath) {
         String mimeType = null;
         try {
             mimeType = Files.probeContentType(filePath);
@@ -111,6 +216,11 @@ public class FileStorageUtils implements StorageUtils {
         return mimeType == null ? URLConnection.guessContentTypeFromName(filePath.toString()) : mimeType;
     }
 
+    public String getContentType(String filename) {
+        Path filePath = resolvePathUnderFileStorage(filename);
+        return probeContentType(filePath);
+    }
+
     /**
      * .temp 제거
      *
@@ -118,19 +228,27 @@ public class FileStorageUtils implements StorageUtils {
      * @return
      */
     public String renameTemp(String physicalFileName) {
-        String rename = physicalFileName.replace(".temp", "");
+        String renamedRelative = stripTempSuffixFromRelativePath(physicalFileName);
+        Path source = resolvePathUnderFileStorage(physicalFileName);
+        Path target = resolvePathUnderFileStorage(renamedRelative);
 
-        //물리적 파일 처리
-        Path path = getStorePath("");
-        File file = path.resolve(physicalFileName).toFile();
-        File renameFile = path.resolve(rename).toFile();
+        File file = source.toFile();
+        File renameFile = target.toFile();
         try {
             file.renameTo(renameFile);
         } catch (NullPointerException ex) {
             // 파일을 찾을 수 없습니다.
             throw new BusinessMessageException(messageUtil.getMessage("valid.file.not_found"));
         }
-        return rename;
+        return renamedRelative;
+    }
+
+    private static String stripTempSuffixFromRelativePath(String relativePath) {
+        String clean = StringUtils.cleanPath(relativePath);
+        if (clean.endsWith(".temp")) {
+            return clean.substring(0, clean.length() - ".temp".length());
+        }
+        return clean.replace(".temp", "");
     }
 
     /**
@@ -141,14 +259,22 @@ public class FileStorageUtils implements StorageUtils {
      * @return
      */
     public String storeBase64File(AttachmentBase64RequestDto requestDto, String basePath) {
+        assertOriginalNamePresent(requestDto.getOriginalName());
+        assertExtensionAllowed(requestDto.getOriginalName());
+
         String filename = getPhysicalFileName(requestDto.getOriginalName(), false);
 
         try {
             Path path = getStorePath(basePath);
-            File file = path.resolve(filename).toFile();
+            Path target = path.resolve(filename).normalize();
+            if (!target.startsWith(path)) {
+                throw new BusinessMessageException(messageUtil.getMessage("valid.file.invalid_name"));
+            }
+            File file = target.toFile();
 
             Base64.Decoder decoder = Base64.getDecoder();
             byte[] decodeBytes = decoder.decode(requestDto.getFileBase64().getBytes());
+            assertWithinMaxSize(decodeBytes.length);
 
             try (FileOutputStream outputStream = new FileOutputStream(file)) {
                 outputStream.write(decodeBytes);
@@ -156,6 +282,9 @@ public class FileStorageUtils implements StorageUtils {
 
             return filename;
 
+        } catch (IllegalArgumentException ex) {
+            log.error("Invalid base64 payload.", ex);
+            throw new BusinessMessageException(messageUtil.getMessage("valid.file.not_saved_try_again"));
         } catch (IOException ex) {
             log.error("Could not stored base 64 file.", ex);
             // 파일을 저장할 수 없습니다. 다시 시도해 주세요.
@@ -182,18 +311,23 @@ public class FileStorageUtils implements StorageUtils {
      * @return
      */
     public String storeFile(MultipartFile file, String basePath, boolean isTemp) {
+        assertOriginalNamePresent(file.getOriginalFilename());
+        assertExtensionAllowed(file.getOriginalFilename());
+        assertWithinMaxSize(file.getSize());
+
         String filename = getPhysicalFileName(file.getOriginalFilename(), isTemp);
 
         try {
-            if (filename.contains("..")) {
-                log.error("Filename contains invalid path sequence : " + filename);
-                // 파일명이 잘못되었습니다.
+            Path path = getStorePath(basePath);
+            Path target = path.resolve(filename).normalize();
+            if (!target.startsWith(path)) {
+                log.error("Filename resolves outside store directory : {}", filename);
                 throw new BusinessMessageException(messageUtil.getMessage("valid.file.invalid_name") + " : " + filename);
             }
 
-            Path path = getStorePath(basePath);
-            Path target = path.resolve(filename);
-            Files.copy(file.getInputStream(), target, StandardCopyOption.REPLACE_EXISTING);
+            try (InputStream inputStream = file.getInputStream()) {
+                Files.copy(inputStream, target, StandardCopyOption.REPLACE_EXISTING);
+            }
 
             return filename;
         } catch (IOException ex) {
@@ -256,9 +390,9 @@ public class FileStorageUtils implements StorageUtils {
      * @return
      */
     public Resource downloadFile(String filename) {
-        Path path = getStorePath("");
         try {
-            Resource resource = new UrlResource(path.resolve(filename).toUri());
+            Path path = resolvePathUnderFileStorage(filename);
+            Resource resource = new UrlResource(path.toUri());
 
             if (resource.exists()) {
                 return resource;
@@ -283,7 +417,7 @@ public class FileStorageUtils implements StorageUtils {
      */
     public AttachmentImageResponseDto loadImage(String imagename) {
         try {
-            Path imagePath = this.fileStorageLocation.resolve(imagename).normalize();
+            Path imagePath = resolvePathUnderFileStorage(imagename);
             try (InputStream is = new FileInputStream(imagePath.toFile())) {
                 try (ByteArrayOutputStream buffer = new ByteArrayOutputStream()) {
                     int read;
@@ -293,7 +427,7 @@ public class FileStorageUtils implements StorageUtils {
                     }
 
                     return AttachmentImageResponseDto.builder()
-                            .mimeType(getContentType(imagename))
+                            .mimeType(probeContentType(imagePath))
                             .data(data)
                             .build();
                 }
@@ -316,9 +450,9 @@ public class FileStorageUtils implements StorageUtils {
      * @return
      */
     public boolean deleteFile(String filename) {
-        Path path = getStorePath("");
         try {
-            return Files.deleteIfExists(path.resolve(filename));
+            Path path = resolvePathUnderFileStorage(filename);
+            return Files.deleteIfExists(path);
         } catch (IOException e) {
             log.error("Could not deleted file.", e);
             return false;

--- a/backend/portal-service/src/main/resources/application.yml
+++ b/backend/portal-service/src/main/resources/application.yml
@@ -30,9 +30,14 @@ spring:
 # config server actuator
 management:
   endpoints:
+    access:
+      default: read-only # 기본적으로 모든 엔드포인트를 읽기 전용으로 설정
+    jmx:
+      exposure:
+        exclude: "*" # JMX에서 모든 엔드포인트 비활성화
     web:
       exposure:
-        include: refresh, health, beans, info
+        include: health, info
 
 info:
   app:

--- a/backend/reserve-check-service/src/main/resources/application.yml
+++ b/backend/reserve-check-service/src/main/resources/application.yml
@@ -11,9 +11,14 @@ server:
 # config server actuator
 management:
   endpoints:
+    access:
+      default: read-only # 기본적으로 모든 엔드포인트를 읽기 전용으로 설정
+    jmx:
+      exposure:
+        exclude: "*" # JMX에서 모든 엔드포인트 비활성화
     web:
       exposure:
-        include: refresh, health, beans, info
+        include: health, info
 
 info:
   app:

--- a/backend/reserve-item-service/src/main/resources/application.yml
+++ b/backend/reserve-item-service/src/main/resources/application.yml
@@ -11,9 +11,14 @@ server:
 # config server actuator
 management:
   endpoints:
+    access:
+      default: read-only # 기본적으로 모든 엔드포인트를 읽기 전용으로 설정
+    jmx:
+      exposure:
+        exclude: "*" # JMX에서 모든 엔드포인트 비활성화
     web:
       exposure:
-        include: refresh, health, beans, info
+        include: health, info
 
 info:
   app:

--- a/backend/reserve-request-service/src/main/resources/application.yml
+++ b/backend/reserve-request-service/src/main/resources/application.yml
@@ -11,9 +11,14 @@ server:
 # config server actuator
 management:
   endpoints:
+    access:
+      default: read-only # 기본적으로 모든 엔드포인트를 읽기 전용으로 설정
+    jmx:
+      exposure:
+        exclude: "*" # JMX에서 모든 엔드포인트 비활성화
     web:
       exposure:
-        include: refresh, health, beans, info
+        include: health, info
 
 info:
   app:

--- a/backend/user-service/src/main/resources/application.yml
+++ b/backend/user-service/src/main/resources/application.yml
@@ -74,12 +74,14 @@ spring:
 # config server actuator
 management:
   endpoints:
+    access:
+      default: read-only # 기본적으로 모든 엔드포인트를 읽기 전용으로 설정
+    jmx:
+      exposure:
+        exclude: "*" # JMX에서 모든 엔드포인트 비활성화
     web:
       exposure:
-        include: refresh, health, beans, info
-  health:
-    mail:
-      enabled: false
+        include: health, info
 
 info:
   app:

--- a/config/application.yml
+++ b/config/application.yml
@@ -18,6 +18,10 @@ eureka:
 file:
   directory: ${app.home:${user.home}}/msa-attach-volume # url 사용시에는 사용되지 않는다
   url: http://${file.hostname:localhost}:8080 # nginx 로 파일 다운로드 처리
+  storage:
+    allowed-extensions: jpg,jpeg,png,gif,bmp,webp,pdf,xlsx,xls,htm,html,txt
+    max-file-size: 10MB
+
 messages:
   directory: ${file.directory}/messages
 

--- a/k8s/applications/backend/apigateway/deployment.yaml
+++ b/k8s/applications/backend/apigateway/deployment.yaml
@@ -25,6 +25,11 @@ spec:
         app: apigateway
         name: apigateway-pod
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       containers:
         - name: apigateway
           image: egovframe/egovframe-msa-edu-backend-apigateway:latest # TODO
@@ -67,4 +72,25 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
             successThreshold: 1
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8000
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "512Mi"
+            limits:
+              cpu: "1000m"
+              memory: "1Gi"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
             failureThreshold: 3

--- a/k8s/applications/backend/board-service/deployment.yaml
+++ b/k8s/applications/backend/board-service/deployment.yaml
@@ -25,6 +25,11 @@ spec:
         app: board-service
         name: board-service-pod
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       tolerations:
         - key: pvc
           operator: Equal
@@ -90,6 +95,27 @@ spec:
             periodSeconds: 10
             successThreshold: 1
             failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 80
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "512Mi"
+            limits:
+              cpu: "1000m"
+              memory: "1Gi"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           volumeMounts:
             - name: backend-volume
               mountPath: /srv/nfs

--- a/k8s/applications/backend/config/deployment.yaml
+++ b/k8s/applications/backend/config/deployment.yaml
@@ -25,6 +25,11 @@ spec:
         app: config
         name: config-pod
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       containers:
         - name: config
           image: egovframe/egovframe-msa-edu-backend-config:latest # TODO
@@ -56,4 +61,25 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 10
             successThreshold: 1
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8888
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "512Mi"
+            limits:
+              cpu: "1000m"
+              memory: "1Gi"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
             failureThreshold: 3

--- a/k8s/applications/backend/discovery/deployment.yaml
+++ b/k8s/applications/backend/discovery/deployment.yaml
@@ -25,6 +25,11 @@ spec:
         app: discovery
         name: discovery-pod
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       containers:
         - name: discovery
           image: egovframe/egovframe-msa-edu-backend-discovery:latest # TODO
@@ -46,4 +51,25 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
             successThreshold: 1
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8761
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "512Mi"
+            limits:
+              cpu: "1000m"
+              memory: "1Gi"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
             failureThreshold: 3

--- a/k8s/applications/backend/portal-service/deployment.yaml
+++ b/k8s/applications/backend/portal-service/deployment.yaml
@@ -25,6 +25,11 @@ spec:
         app: portal-service
         name: portal-service-pod
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       tolerations:
         - key: pvc
           operator: Equal
@@ -90,6 +95,27 @@ spec:
             periodSeconds: 10
             successThreshold: 1
             failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 80
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "512Mi"
+            limits:
+              cpu: "1000m"
+              memory: "1Gi"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           volumeMounts:
             - name: backend-volume
               mountPath: /srv/nfs

--- a/k8s/applications/backend/reserve-check-service/deployment.yaml
+++ b/k8s/applications/backend/reserve-check-service/deployment.yaml
@@ -25,6 +25,11 @@ spec:
         app: reserve-check-service
         name: reserve-check-service-pod
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       containers:
         - name: reserve-check-service
           image: egovframe/egovframe-msa-edu-backend-reserve-check-service:latest # TODO
@@ -84,4 +89,25 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
             successThreshold: 1
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 80
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "512Mi"
+            limits:
+              cpu: "1000m"
+              memory: "1Gi"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
             failureThreshold: 3

--- a/k8s/applications/backend/reserve-item-service/deployment.yaml
+++ b/k8s/applications/backend/reserve-item-service/deployment.yaml
@@ -25,6 +25,11 @@ spec:
         app: reserve-item-service
         name: reserve-item-service-pod
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       containers:
         - name: reserve-item-service
           image: egovframe/egovframe-msa-edu-backend-reserve-item-service:latest # TODO
@@ -84,4 +89,25 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
             successThreshold: 1
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 80
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "512Mi"
+            limits:
+              cpu: "1000m"
+              memory: "1Gi"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
             failureThreshold: 3

--- a/k8s/applications/backend/reserve-request-service/deployment.yaml
+++ b/k8s/applications/backend/reserve-request-service/deployment.yaml
@@ -25,6 +25,11 @@ spec:
         app: reserve-request-service
         name: reserve-request-service-pod
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       containers:
         - name: reserve-request-service
           image: egovframe/egovframe-msa-edu-backend-reserve-request-service:latest # TODO
@@ -84,4 +89,25 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
             successThreshold: 1
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 80
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "512Mi"
+            limits:
+              cpu: "1000m"
+              memory: "1Gi"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
             failureThreshold: 3

--- a/k8s/applications/backend/user-service/deployment.yaml
+++ b/k8s/applications/backend/user-service/deployment.yaml
@@ -25,6 +25,11 @@ spec:
         app: user-service
         name: user-service-pod
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       containers:
         - name: user-service
           image: egovframe/egovframe-msa-edu-backend-user-service:latest # TODO
@@ -84,4 +89,25 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
             successThreshold: 1
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 80
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "512Mi"
+            limits:
+              cpu: "1000m"
+              memory: "1Gi"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
             failureThreshold: 3


### PR DESCRIPTION
## 변경 사유
9개 backend 마이크로서비스 Deployment에 다음이 모두 누락되어 있습니다.
- **livenessProbe** 부재 — startupProbe + readinessProbe만 있어 "기동은 되었지만 hang 상태"를 회수할 수단이 없음
- **resources.requests/limits** 부재 — 스케줄러가 bin-pack을 못 하고, OOM 시 노드 전체가 영향받음
- **container securityContext** 부재 — root 권한 + 전체 capability 보유
- **pod securityContext** 부재 (일부 서비스만) — non-root 강제 없음

운영성/보안 기본값을 일괄 보강합니다.

## 변경 내용
각 9개 서비스 `k8s/applications/backend/<svc>/deployment.yaml`에 다음 추가:
- `livenessProbe` (Actuator /health, initialDelay 60s, period 30s, failureThreshold 3)
- `resources.requests` {cpu: 250m, memory: 512Mi}, `resources.limits` {cpu: 1000m, memory: 1Gi}
- 컨테이너 `securityContext` (allowPrivilegeEscalation=false, capabilities.drop=ALL)
- 누락 시 pod-level `securityContext` (runAsNonRoot, runAsUser/Group/fsGroup=1000)

### 대상 서비스
| 서비스 | 컨테이너 포트 |
|--------|---------------|
| apigateway | 8000 |
| board-service | 80 |
| config | 8888 |
| discovery | 8761 |
| portal-service | 80 |
| reserve-check-service | 80 |
| reserve-item-service | 80 |
| reserve-request-service | 80 |
| user-service | 80 |

## 영향 범위
- 이미지 태그, env 바인딩, volumeMounts, 서비스 라우팅은 변경 없음
- 기존 startupProbe/readinessProbe도 그대로 유지 (livenessProbe는 새로 추가)
- pod-level securityContext의 `runAsUser=1000`은 이미지에서 user 1000을 허용하지 않으면 부팅 실패 가능 — 운영자가 이미지 빌드 시 user 1000을 보장하거나 securityContext 값을 환경에 맞게 조정할 수 있음

## 체크리스트
- [x] 단일 주제(9개 서비스 k8s 운영성 보강)
- [x] 5.0.x 브랜치 대상
- [x] 이미지/env/볼륨/서비스 라우팅 미변경
- [x] 일관 템플릿 (검토 부담 최소화)