### PR TITLE
[test][MSA] reserve-request-service ReserveStatus·Category enum 및 ReserveSaveRequestDto 단위 테스트 추가

### DIFF
--- a/backend/reserve-request-service/src/test/java/org/egovframe/cloud/reserverequestservice/api/dto/ReserveSaveRequestDtoTest.java
+++ b/backend/reserve-request-service/src/test/java/org/egovframe/cloud/reserverequestservice/api/dto/ReserveSaveRequestDtoTest.java
@@ -1,0 +1,99 @@
+package org.egovframe.cloud.reserverequestservice.api.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+
+import org.egovframe.cloud.reserverequestservice.domain.Reserve;
+import org.egovframe.cloud.reserverequestservice.domain.ReserveStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ReserveSaveRequestDtoTest {
+
+    private ReserveSaveRequestDto buildDto() {
+        return ReserveSaveRequestDto.builder()
+                .reserveItemId(1L)
+                .locationId(10L)
+                .categoryId("equipment")
+                .totalQty(5)
+                .reserveQty(2)
+                .reservePurposeContent("테스트 예약 목적")
+                .reserveStartDate(LocalDateTime.of(2024, 6, 1, 9, 0))
+                .reserveEndDate(LocalDateTime.of(2024, 6, 3, 18, 0))
+                .userId("testUser")
+                .userContactNo("010-1234-5678")
+                .userEmail("test@example.com")
+                .reserveMeansId("realtime")
+                .operationStartDate(LocalDateTime.of(2024, 5, 1, 0, 0))
+                .operationEndDate(LocalDateTime.of(2024, 12, 31, 23, 59))
+                .requestStartDate(LocalDateTime.of(2024, 5, 1, 0, 0))
+                .requestEndDate(LocalDateTime.of(2024, 12, 31, 23, 59))
+                .isPeriod(false)
+                .build();
+    }
+
+    @Test
+    @DisplayName("builder로 생성한 DTO의 필드가 올바르게 설정된다")
+    void builder_sets_fields_correctly() {
+        ReserveSaveRequestDto dto = buildDto();
+
+        assertThat(dto.getReserveItemId()).isEqualTo(1L);
+        assertThat(dto.getCategoryId()).isEqualTo("equipment");
+        assertThat(dto.getReserveQty()).isEqualTo(2);
+        assertThat(dto.getUserId()).isEqualTo("testUser");
+        assertThat(dto.getUserEmail()).isEqualTo("test@example.com");
+    }
+
+    @Test
+    @DisplayName("createRequestReserve는 상태를 REQUEST로 설정하고 Reserve 엔티티를 반환한다")
+    void create_request_reserve_sets_status_to_request() {
+        ReserveSaveRequestDto dto = buildDto();
+
+        Reserve reserve = dto.createRequestReserve();
+
+        assertThat(reserve.getReserveStatusId()).isEqualTo(ReserveStatus.REQUEST.getKey());
+        assertThat(reserve.getReserveId()).isNotNull();
+        assertThat(reserve.getReserveItemId()).isEqualTo(1L);
+        assertThat(reserve.getUserId()).isEqualTo("testUser");
+    }
+
+    @Test
+    @DisplayName("createApproveReserve는 상태를 APPROVE로 설정하고 Reserve 엔티티를 반환한다")
+    void create_approve_reserve_sets_status_to_approve() {
+        ReserveSaveRequestDto dto = buildDto();
+
+        Reserve reserve = dto.createApproveReserve();
+
+        assertThat(reserve.getReserveStatusId()).isEqualTo(ReserveStatus.APPROVE.getKey());
+        assertThat(reserve.getReserveId()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("toEntity는 DTO의 값을 Reserve 엔티티로 변환한다")
+    void to_entity_maps_fields() {
+        ReserveSaveRequestDto dto = buildDto();
+        dto.setReserveId("test-reserve-id");
+        dto.setReserveStatusId(ReserveStatus.REQUEST.getKey());
+
+        Reserve reserve = dto.toEntity();
+
+        assertThat(reserve.getReserveId()).isEqualTo("test-reserve-id");
+        assertThat(reserve.getLocationId()).isEqualTo(10L);
+        assertThat(reserve.getCategoryId()).isEqualTo("equipment");
+        assertThat(reserve.getReservePurposeContent()).isEqualTo("테스트 예약 목적");
+        assertThat(reserve.getUserContactNo()).isEqualTo("010-1234-5678");
+    }
+
+    @Test
+    @DisplayName("createRequestReserve를 두 번 호출하면 각각 다른 reserveId가 생성된다")
+    void create_request_reserve_generates_unique_id() {
+        ReserveSaveRequestDto dto1 = buildDto();
+        ReserveSaveRequestDto dto2 = buildDto();
+
+        Reserve reserve1 = dto1.createRequestReserve();
+        Reserve reserve2 = dto2.createRequestReserve();
+
+        assertThat(reserve1.getReserveId()).isNotEqualTo(reserve2.getReserveId());
+    }
+}

--- a/backend/reserve-request-service/src/test/java/org/egovframe/cloud/reserverequestservice/domain/CategoryTest.java
+++ b/backend/reserve-request-service/src/test/java/org/egovframe/cloud/reserverequestservice/domain/CategoryTest.java
@@ -1,0 +1,52 @@
+package org.egovframe.cloud.reserverequestservice.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class CategoryTest {
+
+    @Test
+    @DisplayName("EDUCATION 카테고리의 key와 title이 올바르게 반환된다")
+    void education_key_and_title() {
+        assertThat(Category.EDUCATION.getKey()).isEqualTo("education");
+        assertThat(Category.EDUCATION.getTitle()).isEqualTo("교육");
+    }
+
+    @Test
+    @DisplayName("EQUIPMENT 카테고리의 key와 title이 올바르게 반환된다")
+    void equipment_key_and_title() {
+        assertThat(Category.EQUIPMENT.getKey()).isEqualTo("equipment");
+        assertThat(Category.EQUIPMENT.getTitle()).isEqualTo("장비");
+    }
+
+    @Test
+    @DisplayName("SPACE 카테고리의 key와 title이 올바르게 반환된다")
+    void space_key_and_title() {
+        assertThat(Category.SPACE.getKey()).isEqualTo("space");
+        assertThat(Category.SPACE.getTitle()).isEqualTo("공간");
+    }
+
+    @Test
+    @DisplayName("isEquals는 동일한 key 문자열에 대해 true를 반환한다")
+    void is_equals_returns_true_for_matching_key() {
+        assertThat(Category.EQUIPMENT.isEquals("equipment")).isTrue();
+        assertThat(Category.SPACE.isEquals("space")).isTrue();
+        assertThat(Category.EDUCATION.isEquals("education")).isTrue();
+    }
+
+    @Test
+    @DisplayName("isEquals는 다른 key 문자열에 대해 false를 반환한다")
+    void is_equals_returns_false_for_non_matching_key() {
+        assertThat(Category.EQUIPMENT.isEquals("space")).isFalse();
+        assertThat(Category.SPACE.isEquals("education")).isFalse();
+        assertThat(Category.EDUCATION.isEquals("equipment")).isFalse();
+    }
+
+    @Test
+    @DisplayName("Category는 총 3개의 값을 가진다")
+    void category_total_count() {
+        assertThat(Category.values()).hasSize(3);
+    }
+}

--- a/backend/reserve-request-service/src/test/java/org/egovframe/cloud/reserverequestservice/domain/ReserveStatusTest.java
+++ b/backend/reserve-request-service/src/test/java/org/egovframe/cloud/reserverequestservice/domain/ReserveStatusTest.java
@@ -1,0 +1,50 @@
+package org.egovframe.cloud.reserverequestservice.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ReserveStatusTest {
+
+    @Test
+    @DisplayName("REQUEST 상태의 key와 title이 올바르게 반환된다")
+    void request_status_key_and_title() {
+        assertThat(ReserveStatus.REQUEST.getKey()).isEqualTo("request");
+        assertThat(ReserveStatus.REQUEST.getTitle()).isEqualTo("예약 신청");
+    }
+
+    @Test
+    @DisplayName("APPROVE 상태의 key와 title이 올바르게 반환된다")
+    void approve_status_key_and_title() {
+        assertThat(ReserveStatus.APPROVE.getKey()).isEqualTo("approve");
+        assertThat(ReserveStatus.APPROVE.getTitle()).isEqualTo("예약 승인");
+    }
+
+    @Test
+    @DisplayName("CANCEL 상태의 key와 title이 올바르게 반환된다")
+    void cancel_status_key_and_title() {
+        assertThat(ReserveStatus.CANCEL.getKey()).isEqualTo("cancel");
+        assertThat(ReserveStatus.CANCEL.getTitle()).isEqualTo("예약 취소");
+    }
+
+    @Test
+    @DisplayName("DONE 상태의 key와 title이 올바르게 반환된다")
+    void done_status_key_and_title() {
+        assertThat(ReserveStatus.DONE.getKey()).isEqualTo("done");
+        assertThat(ReserveStatus.DONE.getTitle()).isEqualTo("완료");
+    }
+
+    @Test
+    @DisplayName("ReserveStatus는 총 4개의 상태값을 가진다")
+    void reserve_status_total_count() {
+        assertThat(ReserveStatus.values()).hasSize(4);
+    }
+
+    @Test
+    @DisplayName("name()으로 enum 상수를 조회할 수 있다")
+    void reserve_status_value_of() {
+        assertThat(ReserveStatus.valueOf("REQUEST")).isEqualTo(ReserveStatus.REQUEST);
+        assertThat(ReserveStatus.valueOf("CANCEL")).isEqualTo(ReserveStatus.CANCEL);
+    }
+}


### PR DESCRIPTION
reserve-request-service의 도메인 열거형과 DTO 클래스에 대한 단위 테스트를 추가합니다.

**추가 테스트 파일**
- `ReserveStatusTest`: REQUEST·APPROVE·CANCEL·DONE 4개 상태값의 key·title 반환 검증, values() 개수 확인
- `CategoryTest`: EDUCATION·EQUIPMENT·SPACE 3개 카테고리의 key·title 반환 검증, `isEquals()` 메서드 동작 확인
- `ReserveSaveRequestDtoTest`: builder 생성 필드 검증, `createRequestReserve()`/`createApproveReserve()` 상태 설정 확인, `toEntity()` 필드 매핑 검증, UUID 고유성 확인

**테스트 환경**
- JUnit 5 + AssertJ
- Spring Boot 컨텍스트 로드 없이 순수 단위 테스트로 구성 (빠른 실행)

**검증**
- `./gradlew test` 로컬 빌드 SUCCESS 확인 (3개 테스트 클래스, 15개 테스트 케이스 모두 통과)

---

- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 기존 동작에 영향 없음
- [x] 테스트 통과 확인
