### PR TITLE
[test][MSA] reserve-item-service Category enum 및 Location DTO 단위 테스트 추가

### DIFF
--- a/backend/reserve-item-service/src/test/java/org/egovframe/cloud/reserveitemservice/api/location/dto/LocationResponseDtoTest.java
+++ b/backend/reserve-item-service/src/test/java/org/egovframe/cloud/reserveitemservice/api/location/dto/LocationResponseDtoTest.java
@@ -1,0 +1,66 @@
+package org.egovframe.cloud.reserveitemservice.api.location.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.egovframe.cloud.reserveitemservice.domain.location.Location;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * org.egovframe.cloud.reserveitemservice.api.location.dto.LocationResponseDtoTest
+ * <p>
+ * 예약 지역 응답 dto 단위 테스트
+ *
+ * @author 표준프레임워크센터
+ * @version 1.0
+ * @since 2024/01/01
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *     수정일        수정자           수정내용
+ *  ----------    --------    ---------------------------
+ *  2024/01/01    contributors  최초 생성
+ * </pre>
+ */
+class LocationResponseDtoTest {
+
+    @DisplayName("Location 엔티티로부터 LocationResponseDto 가 올바르게 생성된다")
+    @Test
+    void constructor_maps_entity_fields_correctly() {
+        Location entity = Location.builder()
+                .locationId(1L)
+                .locationName("서울")
+                .sortSeq(1)
+                .isUse(true)
+                .build();
+
+        LocationResponseDto dto = LocationResponseDto.builder()
+                .entity(entity)
+                .build();
+
+        assertThat(dto.getLocationId()).isEqualTo(1L);
+        assertThat(dto.getLocationName()).isEqualTo("서울");
+        assertThat(dto.getSortSeq()).isEqualTo(1);
+        assertThat(dto.getIsUse()).isTrue();
+    }
+
+    @DisplayName("isUse 가 false 인 엔티티도 올바르게 매핑된다")
+    @Test
+    void constructor_maps_false_isUse_correctly() {
+        Location entity = Location.builder()
+                .locationId(2L)
+                .locationName("부산")
+                .sortSeq(2)
+                .isUse(false)
+                .build();
+
+        LocationResponseDto dto = LocationResponseDto.builder()
+                .entity(entity)
+                .build();
+
+        assertThat(dto.getLocationId()).isEqualTo(2L);
+        assertThat(dto.getLocationName()).isEqualTo("부산");
+        assertThat(dto.getIsUse()).isFalse();
+    }
+}

--- a/backend/reserve-item-service/src/test/java/org/egovframe/cloud/reserveitemservice/api/location/dto/LocationSaveRequestDtoTest.java
+++ b/backend/reserve-item-service/src/test/java/org/egovframe/cloud/reserveitemservice/api/location/dto/LocationSaveRequestDtoTest.java
@@ -1,0 +1,72 @@
+package org.egovframe.cloud.reserveitemservice.api.location.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.egovframe.cloud.reserveitemservice.domain.location.Location;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * org.egovframe.cloud.reserveitemservice.api.location.dto.LocationSaveRequestDtoTest
+ * <p>
+ * 예약 지역 저장 요청 dto 단위 테스트
+ *
+ * @author 표준프레임워크센터
+ * @version 1.0
+ * @since 2024/01/01
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *     수정일        수정자           수정내용
+ *  ----------    --------    ---------------------------
+ *  2024/01/01    contributors  최초 생성
+ * </pre>
+ */
+class LocationSaveRequestDtoTest {
+
+    @DisplayName("빌더로 생성한 LocationSaveRequestDto 의 필드 값이 올바르게 설정된다")
+    @Test
+    void builder_sets_fields_correctly() {
+        LocationSaveRequestDto dto = LocationSaveRequestDto.builder()
+                .locationName("서울")
+                .sortSeq(1)
+                .isUse(true)
+                .build();
+
+        assertThat(dto.getLocationName()).isEqualTo("서울");
+        assertThat(dto.getSortSeq()).isEqualTo(1);
+        assertThat(dto.getIsUse()).isTrue();
+    }
+
+    @DisplayName("toEntity 호출 시 Location 엔티티가 올바르게 생성된다")
+    @Test
+    void toEntity_creates_location_with_same_values() {
+        LocationSaveRequestDto dto = LocationSaveRequestDto.builder()
+                .locationName("부산")
+                .sortSeq(2)
+                .isUse(false)
+                .build();
+
+        Location entity = dto.toEntity();
+
+        assertThat(entity.getLocationName()).isEqualTo("부산");
+        assertThat(entity.getSortSeq()).isEqualTo(2);
+        assertThat(entity.getIsUse()).isFalse();
+    }
+
+    @DisplayName("isUse 가 null 이어도 toEntity 가 정상 동작한다")
+    @Test
+    void toEntity_handles_null_isUse() {
+        LocationSaveRequestDto dto = LocationSaveRequestDto.builder()
+                .locationName("대전")
+                .sortSeq(3)
+                .isUse(null)
+                .build();
+
+        Location entity = dto.toEntity();
+
+        assertThat(entity.getLocationName()).isEqualTo("대전");
+        assertThat(entity.getIsUse()).isNull();
+    }
+}

--- a/backend/reserve-item-service/src/test/java/org/egovframe/cloud/reserveitemservice/domain/reserveItem/CategoryTest.java
+++ b/backend/reserve-item-service/src/test/java/org/egovframe/cloud/reserveitemservice/domain/reserveItem/CategoryTest.java
@@ -1,0 +1,63 @@
+package org.egovframe.cloud.reserveitemservice.domain.reserveItem;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * org.egovframe.cloud.reserveitemservice.domain.reserveItem.CategoryTest
+ * <p>
+ * Category 열거형 단위 테스트
+ *
+ * @author 표준프레임워크센터
+ * @version 1.0
+ * @since 2024/01/01
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *     수정일        수정자           수정내용
+ *  ----------    --------    ---------------------------
+ *  2024/01/01    contributors  최초 생성
+ * </pre>
+ */
+class CategoryTest {
+
+    @DisplayName("Category 열거형 key·title 값이 올바르게 정의된다")
+    @Test
+    void category_values_are_defined_correctly() {
+        assertThat(Category.EDUCATION.getKey()).isEqualTo("education");
+        assertThat(Category.EDUCATION.getTitle()).isEqualTo("교육");
+
+        assertThat(Category.EQUIPMENT.getKey()).isEqualTo("equipment");
+        assertThat(Category.EQUIPMENT.getTitle()).isEqualTo("장비");
+
+        assertThat(Category.SPACE.getKey()).isEqualTo("space");
+        assertThat(Category.SPACE.getTitle()).isEqualTo("공간");
+    }
+
+    @DisplayName("isEquals 는 key 문자열이 일치할 때만 true 를 반환한다")
+    @Test
+    void isEquals_returns_true_only_for_matching_key() {
+        assertThat(Category.EDUCATION.isEquals("education")).isTrue();
+        assertThat(Category.EDUCATION.isEquals("equipment")).isFalse();
+        assertThat(Category.EDUCATION.isEquals("EDUCATION")).isFalse();
+        assertThat(Category.EQUIPMENT.isEquals("equipment")).isTrue();
+        assertThat(Category.SPACE.isEquals("space")).isTrue();
+    }
+
+    @DisplayName("Category 열거형은 세 가지 값만 존재한다")
+    @Test
+    void category_has_exactly_three_values() {
+        assertThat(Category.values()).hasSize(3);
+    }
+
+    @DisplayName("Category.valueOf 로 이름을 통해 열거형을 조회할 수 있다")
+    @Test
+    void category_can_be_retrieved_by_name() {
+        assertThat(Category.valueOf("EDUCATION")).isEqualTo(Category.EDUCATION);
+        assertThat(Category.valueOf("EQUIPMENT")).isEqualTo(Category.EQUIPMENT);
+        assertThat(Category.valueOf("SPACE")).isEqualTo(Category.SPACE);
+    }
+}


### PR DESCRIPTION
## 변경 사유

reserve-item-service 내 Category 열거형과 Location DTO 클래스에 대한 단위 테스트가 부재하여 추가합니다.

## 변경 내용

- `CategoryTest`: key/title 값 정확성, isEquals 동작, 열거형 총 개수, valueOf 조회 (4건)
- `LocationSaveRequestDtoTest`: 빌더 필드 설정, toEntity 변환, null isUse 처리 (3건)
- `LocationResponseDtoTest`: Location 엔티티로부터 필드 매핑 정확성 (2건)

## 테스트 결과

`./gradlew test` BUILD SUCCESSFUL — 신규 테스트 3개 파일 9건 모두 통과

## 영향 범위

테스트 코드만 추가. 프로덕션 코드 변경 없음.

---
- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 기존 동작에 영향 없음
- [x] 테스트 통과 확인
