### PR TITLE
[chore][MSA] config-service·discovery-service k8s autoscaler(HPA) 매니페스트 추가

### DIFF
--- a/k8s/applications/backend/config/autoscaler.yaml
+++ b/k8s/applications/backend/config/autoscaler.yaml
@@ -1,0 +1,17 @@
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: config-hpa-cpu
+  labels:
+    env: production
+    tier: backend
+    app: config
+    name: config-hpa-cpu
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: config-deployment
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 70

--- a/k8s/applications/backend/discovery/autoscaler.yaml
+++ b/k8s/applications/backend/discovery/autoscaler.yaml
@@ -1,0 +1,17 @@
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: discovery-hpa-cpu
+  labels:
+    env: production
+    tier: backend
+    app: discovery
+    name: discovery-hpa-cpu
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: discovery-deployment
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 70


### PR DESCRIPTION
## 변경 사유
`apigateway`, `board-service` 등 다른 서비스는 모두 `autoscaler.yaml`(HPA)을 보유하고 있으나 `config`, `discovery` 두 서비스만 누락되어 일관성을 위해 추가

## 변경 내용
- `k8s/applications/backend/config/autoscaler.yaml` 신규
- `k8s/applications/backend/discovery/autoscaler.yaml` 신규
- 기존 패턴 동일: CPU 70% 기준, minReplicas 1, maxReplicas 3

## 영향 범위
- 두 서비스의 k8s 배포 시 HPA 자동 활성화
- 기존 deployment·service 매니페스트와 충돌 없음

## 체크리스트
- [x] 단일 주제만 다룸
- [x] 기존 동작 호환
