### PR TITLE
[security][main] webjars-locator-core 0.53 → 0.59 (CVE-2024-38999)

### DIFF
--- a/backend/board-service/build.gradle
+++ b/backend/board-service/build.gradle
@@ -85,7 +85,7 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     implementation 'org.javassist:javassist:3.29.2-GA'
-    implementation 'org.webjars:webjars-locator-core:0.53'
+    implementation 'org.webjars:webjars-locator-core:0.59'
     implementation 'com.google.guava:guava:32.1.3-jre'
 }
 

--- a/backend/portal-service/build.gradle
+++ b/backend/portal-service/build.gradle
@@ -87,7 +87,7 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     implementation 'org.javassist:javassist:3.29.2-GA'
-    implementation 'org.webjars:webjars-locator-core:0.53'
+    implementation 'org.webjars:webjars-locator-core:0.59'
     implementation 'com.google.guava:guava:32.1.3-jre'
 }
 

--- a/backend/reserve-check-service/build.gradle
+++ b/backend/reserve-check-service/build.gradle
@@ -83,7 +83,7 @@ dependencies {
     testImplementation 'io.projectreactor:reactor-test'
     testImplementation 'org.springframework.security:spring-security-test'
 
-    implementation 'org.webjars:webjars-locator-core:0.53'
+    implementation 'org.webjars:webjars-locator-core:0.59'
 }
 
 test {

--- a/backend/reserve-item-service/build.gradle
+++ b/backend/reserve-item-service/build.gradle
@@ -82,7 +82,7 @@ dependencies {
     testImplementation 'io.projectreactor:reactor-test'
     testImplementation 'org.springframework.security:spring-security-test'
 
-    implementation 'org.webjars:webjars-locator-core:0.53'
+    implementation 'org.webjars:webjars-locator-core:0.59'
 }
 
 test {

--- a/backend/reserve-request-service/build.gradle
+++ b/backend/reserve-request-service/build.gradle
@@ -84,7 +84,7 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.springframework.amqp:spring-rabbit-test'
 
-    implementation 'org.webjars:webjars-locator-core:0.53'
+    implementation 'org.webjars:webjars-locator-core:0.59'
 }
 
 test {

--- a/backend/user-service/build.gradle
+++ b/backend/user-service/build.gradle
@@ -93,7 +93,7 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
 
     implementation 'org.javassist:javassist:3.29.2-GA'
-    implementation 'org.webjars:webjars-locator-core:0.53'
+    implementation 'org.webjars:webjars-locator-core:0.59'
     implementation 'com.google.guava:guava:32.1.3-jre'
 }
 


### PR DESCRIPTION
## 변경 사유

CVE-2024-38999: `webjars-locator-core` < 0.59 버전에서 WebJar 경로 처리 중
정규표현식을 사용하는 코드에 ReDoS(Regular Expression Denial of Service) 취약점이 존재합니다.
공격자가 조작된 경로를 요청할 경우 서버 스레드를 장시간 점유하여 서비스 가용성에 영향을 줄 수 있습니다.

## 변경 내용

`egovframe-cloud-module-common`은 이미 `webjarLocatorCoreVersion = '0.59'`로 관리되고 있었으나,
하위 6개 서비스 모듈이 `0.53`을 하드코딩하여 취약 상태였습니다.

변경 파일:
- `backend/board-service/build.gradle`
- `backend/portal-service/build.gradle`
- `backend/reserve-check-service/build.gradle`
- `backend/reserve-item-service/build.gradle`
- `backend/reserve-request-service/build.gradle`
- `backend/user-service/build.gradle`

패치: `org.webjars:webjars-locator-core:0.53` → `0.59`

## 테스트 / 영향 범위

- `board-service` 대상으로 `./gradlew dependencies --configuration compileClasspath` 실행 → BUILD SUCCESSFUL, `webjars-locator-core:0.59` 정상 해석 확인
- webjars-locator-core는 WebJar 정적 자원 경로 조회에만 사용되므로 기존 비즈니스 로직에 영향 없음
- 0.53 → 0.59는 마이너 패치로 하위 호환성 유지

## 체크리스트

- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 기존 동작에 영향 없음
- [x] 빌드 확인 완료
