### PR TITLE
[chore] docker-compose 예약 서비스 3종 추가

### DIFF
--- a/docker-compose/app/docker-compose.yml
+++ b/docker-compose/app/docker-compose.yml
@@ -120,6 +120,72 @@ services:
       config:
         condition: service_healthy
 
+  reserveitemservice:
+    container_name: reserveitemservice
+    image: egovframe/msa-reserve-item-service:latest
+    restart: always
+    volumes:
+      - ${HOME}/workspace:/usr/app/msa-attach-volume
+    environment:
+      SPRING_CLOUD_CONFIG_URI: http://config:8888
+      SPRING_PROFILES_ACTIVE: default
+      MESSAGES_DIRECTORY: /usr/app/msa-attach-volume/messages
+      APP_HOME: /usr/app
+      logstash_hostname: logstash:5001
+      EUREKA_INSTANCE_HOSTNAME: discovery
+      MYSQL_HOSTNAME: mysql
+      RABBITMQ_HOSTNAME: rabbitmq
+      ZIPKIN_HOSTNAME: zipkin
+      TOKEN_SECRET: egovframe
+      TZ: Asia/Seoul
+    depends_on:
+      config:
+        condition: service_healthy
+
+  reservecheckservice:
+    container_name: reservecheckservice
+    image: egovframe/msa-reserve-check-service:latest
+    restart: always
+    volumes:
+      - ${HOME}/workspace:/usr/app/msa-attach-volume
+    environment:
+      SPRING_CLOUD_CONFIG_URI: http://config:8888
+      SPRING_PROFILES_ACTIVE: default
+      MESSAGES_DIRECTORY: /usr/app/msa-attach-volume/messages
+      APP_HOME: /usr/app
+      logstash_hostname: logstash:5001
+      EUREKA_INSTANCE_HOSTNAME: discovery
+      MYSQL_HOSTNAME: mysql
+      RABBITMQ_HOSTNAME: rabbitmq
+      ZIPKIN_HOSTNAME: zipkin
+      TOKEN_SECRET: egovframe
+      TZ: Asia/Seoul
+    depends_on:
+      config:
+        condition: service_healthy
+
+  reserverequestservice:
+    container_name: reserverequestservice
+    image: egovframe/msa-reserve-request-service:latest
+    restart: always
+    volumes:
+      - ${HOME}/workspace:/usr/app/msa-attach-volume
+    environment:
+      SPRING_CLOUD_CONFIG_URI: http://config:8888
+      SPRING_PROFILES_ACTIVE: default
+      MESSAGES_DIRECTORY: /usr/app/msa-attach-volume/messages
+      APP_HOME: /usr/app
+      logstash_hostname: logstash:5001
+      EUREKA_INSTANCE_HOSTNAME: discovery
+      MYSQL_HOSTNAME: mysql
+      RABBITMQ_HOSTNAME: rabbitmq
+      ZIPKIN_HOSTNAME: zipkin
+      TOKEN_SECRET: egovframe
+      TZ: Asia/Seoul
+    depends_on:
+      config:
+        condition: service_healthy
+
 networks:
   default:
     name: egov-network

--- a/docker-compose/app/service/docker-compose.yml
+++ b/docker-compose/app/service/docker-compose.yml
@@ -65,6 +65,72 @@ services:
       config:
         condition: service_healthy
 
+  reserveitemservice:
+    container_name: reserveitemservice
+    image: egovframe/msa-reserve-item-service:latest
+    restart: always
+    volumes:
+      - ${HOME}/workspace:/usr/app/msa-attach-volume
+    environment:
+      SPRING_CLOUD_CONFIG_URI: http://config:8888
+      SPRING_PROFILES_ACTIVE: default
+      MESSAGES_DIRECTORY: /usr/app/msa-attach-volume/messages
+      APP_HOME: /usr/app
+      logstash_hostname: logstash:5001
+      EUREKA_INSTANCE_HOSTNAME: discovery
+      MYSQL_HOSTNAME: mysql
+      RABBITMQ_HOSTNAME: rabbitmq
+      ZIPKIN_HOSTNAME: zipkin
+      TOKEN_SECRET: egovframe
+      TZ: Asia/Seoul
+    depends_on:
+      config:
+        condition: service_healthy
+
+  reservecheckservice:
+    container_name: reservecheckservice
+    image: egovframe/msa-reserve-check-service:latest
+    restart: always
+    volumes:
+      - ${HOME}/workspace:/usr/app/msa-attach-volume
+    environment:
+      SPRING_CLOUD_CONFIG_URI: http://config:8888
+      SPRING_PROFILES_ACTIVE: default
+      MESSAGES_DIRECTORY: /usr/app/msa-attach-volume/messages
+      APP_HOME: /usr/app
+      logstash_hostname: logstash:5001
+      EUREKA_INSTANCE_HOSTNAME: discovery
+      MYSQL_HOSTNAME: mysql
+      RABBITMQ_HOSTNAME: rabbitmq
+      ZIPKIN_HOSTNAME: zipkin
+      TOKEN_SECRET: egovframe
+      TZ: Asia/Seoul
+    depends_on:
+      config:
+        condition: service_healthy
+
+  reserverequestservice:
+    container_name: reserverequestservice
+    image: egovframe/msa-reserve-request-service:latest
+    restart: always
+    volumes:
+      - ${HOME}/workspace:/usr/app/msa-attach-volume
+    environment:
+      SPRING_CLOUD_CONFIG_URI: http://config:8888
+      SPRING_PROFILES_ACTIVE: default
+      MESSAGES_DIRECTORY: /usr/app/msa-attach-volume/messages
+      APP_HOME: /usr/app
+      logstash_hostname: logstash:5001
+      EUREKA_INSTANCE_HOSTNAME: discovery
+      MYSQL_HOSTNAME: mysql
+      RABBITMQ_HOSTNAME: rabbitmq
+      ZIPKIN_HOSTNAME: zipkin
+      TOKEN_SECRET: egovframe
+      TZ: Asia/Seoul
+    depends_on:
+      config:
+        condition: service_healthy
+
 networks:
   default:
     name: egov-network


### PR DESCRIPTION
## 변경 사유

`docker-compose/app/docker-compose.yml` 및 `docker-compose/app/service/docker-compose.yml`에 예약 관련 3개 서비스(reserve-item-service, reserve-check-service, reserve-request-service)가 정의되어 있지 않아, docker compose로 전체 애플리케이션을 통합 기동할 수 없는 문제가 있었음.

## 변경 내용

두 파일 모두에 아래 3개 서비스 블록 추가:

- `reserveitemservice` — `egovframe/msa-reserve-item-service:latest`
- `reservecheckservice` — `egovframe/msa-reserve-check-service:latest`
- `reserverequestservice` — `egovframe/msa-reserve-request-service:latest`

기존 board/user/portal 서비스 블록의 환경변수(CONFIG_URI, PROFILES_ACTIVE, MYSQL_HOSTNAME, RABBITMQ_HOSTNAME, ZIPKIN_HOSTNAME 등), volumes, depends_on, 네트워크 패턴을 그대로 따라 일관성을 유지함.

각 서비스는 `server.port: 0`(동적 포트)으로 설정되어 있어 호스트 포트 매핑 없이 Eureka를 통해 서비스 디스커버리됨. 별도 포트 선언 불필요.

## 검증

- `docker compose -f docker-compose/app/docker-compose.yml config` 문법 검증 통과
- `service/docker-compose.yml`은 상위 compose와 함께 사용하는 파일로, 기존 서비스들도 동일하게 depends_on: config 패턴 사용 중

## 체크리스트

- [x] 단일 주제만 다룸 (docker-compose 누락 서비스 추가)
- [x] 기존 서비스 블록 패턴과 동일한 형식 유지
- [x] 포트 충돌 없음 (동적 포트 방식)
- [x] 기존 동작에 영향 없음
