### PR TITLE
[fix][portal] escapeHtmlNl 정규식 문자 클래스 버그 수정 ([p|div] → (p|div))

### DIFF
--- a/frontend/portal/src/utils/index.test.ts
+++ b/frontend/portal/src/utils/index.test.ts
@@ -1,0 +1,40 @@
+import { escapeHtml, escapeHtmlNl, nl2Br } from './index'
+
+describe('escapeHtmlNl', () => {
+  it('converts closing p/div tags to newlines', () => {
+    expect(escapeHtmlNl('<p>a</p><div>b</div>')).toBe('a\nb\n')
+  })
+
+  it('handles closing tags case-insensitively', () => {
+    expect(escapeHtmlNl('<P>a</P><DIV>b</DIV>')).toBe('a\nb\n')
+  })
+
+  it('strips other tags without inserting a newline', () => {
+    // <i>/<span> 같은 태그는 제거만 하고 줄바꿈을 넣지 않아야 한다.
+    expect(escapeHtmlNl('x<i>italic</i>y')).toBe('xitalicy')
+    expect(escapeHtmlNl('m<span>s</span>n')).toBe('msn')
+  })
+
+  it('does not treat tags built from p/d/i/v letters as paragraph breaks', () => {
+    // 정규식 문자클래스 버그([p|div]) 회귀 방지: </v>, </dip> 등은 줄바꿈이 아니다.
+    expect(escapeHtmlNl('a</v>b')).toBe('ab')
+    expect(escapeHtmlNl('a</dip>b')).toBe('ab')
+  })
+
+  it('removes &nbsp; entities', () => {
+    expect(escapeHtmlNl('a&nbsp;b')).toBe('ab')
+  })
+})
+
+describe('escapeHtml', () => {
+  it('removes all html tags', () => {
+    expect(escapeHtml('<p>hello <b>world</b></p>')).toBe('hello world')
+  })
+})
+
+describe('nl2Br', () => {
+  it('converts newlines to <br /> tags', () => {
+    expect(nl2Br('a\nb')).toBe('a<br />b')
+    expect(nl2Br('a\r\nb')).toBe('a<br />b')
+  })
+})

--- a/frontend/portal/src/utils/index.ts
+++ b/frontend/portal/src/utils/index.ts
@@ -59,7 +59,7 @@ export const escapeHtml = html => {
 
 // 개행 태그(p, div) 제거
 export const escapeHtmlNl = html => {
-  return html.replace(/(<[/]([p|div]+)>)/gi, '\n').replace(/(<([^>]+)>)/gi, '').replace(/(\&nbsp\;)/gi, '')
+  return html.replace(/(<[/](p|div)>)/gi, '\n').replace(/(<([^>]+)>)/gi, '').replace(/(\&nbsp\;)/gi, '')
 }
 
 // 개행 문자를 br 태그로 변환


### PR DESCRIPTION
## 개요

portal 게시물 내용 미리보기에 사용되는 `escapeHtmlNl`(`frontend/portal/src/utils/index.ts`)의 정규식에 문자 클래스 버그가 있어 수정합니다.

## 문제

```js
html.replace(/(<[/]([p|div]+)>)/gi, '\n')
```

`[p|div]` 는 의도한 `</p>` / `</div>` 대체(alternation)가 아니라 **문자 클래스**로 해석되어 `{ p, |, d, i, v }` 중 한 글자에 매칭됩니다. 따라서 `</p>` · `</div>` 외에도 이름이 해당 글자들로만 구성된 닫는 태그(`</i>`, `</v>`, `</dip>` 등)까지 줄바꿈(`\n`)으로 변환되어, 게시물 미리보기(`components/Main/MainSM.tsx`)에 의도치 않은 개행이 삽입됩니다.

### 재현

| 입력 | 기존(버그) | 수정 후 |
|------|-----------|---------|
| `x<i>italic</i>y` | `xitalic\ny` | `xitalicy` |
| `a</v>b` | `a\nb` | `ab` |
| `<p>a</p><div>b</div>` | `a\nb\n` | `a\nb\n` (동일) |

## 수정

문자 클래스 `[p|div]` 를 그룹 alternation `(p|div)` 로 교정합니다. 1줄 변경이며 동작을 보존합니다.

- `</p>` / `</div>` → 줄바꿈 (기존 의도 유지)
- 그 외 태그 → 제거(개행 없음)

## 검증

`frontend/portal/src/utils/index.test.ts` 에 `escapeHtmlNl` / `escapeHtml` / `nl2Br` 단위 테스트 7건을 추가했습니다. 회귀 케이스(`</v>`, `</dip>`)는 기존 코드에서 실패하고 수정 후 통과합니다.

```
Test Suites: 1 passed, 1 total
Tests:       7 passed, 7 total
```