### PR TITLE
fix: 파일 이름 변경(renameTemp) 실패가 조용히 무시되는 문제 수정

### DIFF
--- a/backend/portal-service/src/main/java/org/egovframe/cloud/portalservice/utils/FileStorageUtils.java
+++ b/backend/portal-service/src/main/java/org/egovframe/cloud/portalservice/utils/FileStorageUtils.java
@@ -234,10 +234,11 @@ public class FileStorageUtils implements StorageUtils {
 
         File file = source.toFile();
         File renameFile = target.toFile();
-        try {
-            file.renameTo(renameFile);
-        } catch (NullPointerException ex) {
-            // 파일을 찾을 수 없습니다.
+        // File.renameTo는 실패 시 예외가 아니라 false를 반환하므로 반환값을 검사한다.
+        // (기존 catch(NullPointerException)는 rename 실패를 감지하지 못해 실패가 조용히 무시되어
+        //  존재하지 않는 파일 경로가 그대로 저장되는 문제가 있었다.)
+        if (!file.renameTo(renameFile)) {
+            // 원본 파일을 찾을 수 없거나 이름 변경에 실패한 경우
             throw new BusinessMessageException(messageUtil.getMessage("valid.file.not_found"));
         }
         return renamedRelative;


### PR DESCRIPTION
## 개요

`FileStorageUtils.renameTemp`는 업로드 임시 파일(`.temp`)을 정식 파일명으로 변경한 뒤 그 경로를 첨부 정보로 저장합니다. 그러나 `File.renameTo`는 실패 시 예외가 아니라 `false`를 반환하는데, 기존 코드는 반환값을 무시하고 `NullPointerException`만 catch 했습니다.

이로 인해 원본 파일이 없거나 권한 문제 등으로 rename이 실패해도 예외 없이 정상 경로처럼 반환되어, **실제로 존재하지 않는 파일 경로가 첨부 정보로 저장**될 수 있었습니다. (`catch (NullPointerException)`은 renameTo의 실패 신호가 아니므로 사실상 도달하지 않습니다.)

## 변경 내용

```java
if (!file.renameTo(renameFile)) {
    throw new BusinessMessageException(messageUtil.getMessage("valid.file.not_found"));
}
```

`renameTo`의 반환값을 검사해 실패 시 `BusinessMessageException`을 던지도록 수정하고, 도달 불가능하던 `catch (NullPointerException)`을 제거했습니다.

## 검증

`./gradlew compileJava` 빌드 성공.

단위테스트 추가를 시도했으나, `portal-service`의 테스트 런타임 클래스패스에 `log4j-slf4j2-impl`과 `log4j-to-slf4j`가 함께 존재하여 로거 초기화 시 `LoggingException: log4j-slf4j2-impl cannot be present with log4j-to-slf4j`가 발생해 일반 단위테스트 구동이 막혀 있습니다. 이는 본 수정과 무관한 별도 이슈로 보이며, 필요 시 별도로 정리하겠습니다.
