### PR TITLE
fix: portal-service log4j 이중 바인딩 충돌 제거

### DIFF
--- a/backend/portal-service/build.gradle
+++ b/backend/portal-service/build.gradle
@@ -29,6 +29,11 @@ ext {
 dependencies {
 //    implementation files('../module-common/build/libs/egovframe-cloud-module-common.jar') // @ComponentScan(basePackages={"org.egovframe.cloud"}) 추가해야 적용된다
     implementation("org.egovframe.cloud:egovframe-cloud-module-common:${egovframeBootParentVersion}") {
+        // egovframe-rte-fdl-logging이 log4j-slf4j2-impl(slf4j→log4j2)을 끌어와
+        // Spring Boot 기본 logback의 log4j-to-slf4j(log4j2→slf4j)와 충돌하므로 제외한다.
+        // (직접 의존인 egovframe-rte-fdl-cmmn에는 이미 동일 제외가 적용되어 있으나
+        //  module-common 경유 전이 의존에는 누락되어 있었음)
+        exclude group: 'org.egovframe.rte', module: 'egovframe-rte-fdl-logging'
         exclude group: 'commons-logging', module: 'commons-logging'
     }
     implementation("org.egovframe.rte:egovframe-rte-fdl-cmmn:${egovframeBootParentVersion}") {

--- a/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/utils/LoggingBindingSmokeTest.java
+++ b/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/utils/LoggingBindingSmokeTest.java
@@ -1,0 +1,16 @@
+package org.egovframe.cloud.portalservice.utils;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+class LoggingBindingSmokeTest {
+    @Test
+    void slf4jLoggerInitializesWithoutLog4jConflict() {
+        assertDoesNotThrow(() -> {
+            Logger log = LoggerFactory.getLogger(LoggingBindingSmokeTest.class);
+            log.info("logging smoke");
+        });
+    }
+}


### PR DESCRIPTION
## 개요

`portal-service`에서 단위테스트 실행 시 로거 초기화 단계에서 다음 예외가 발생해 테스트가 실패합니다.

```
org.apache.logging.log4j.LoggingException: log4j-slf4j2-impl cannot be present with log4j-to-slf4j
```

SLF4J 바인딩이 두 개(`log4j-slf4j2-impl`: slf4j→log4j2, `log4j-to-slf4j`: log4j2→slf4j) 동시에 클래스패스에 존재하기 때문입니다.

## 원인

- `log4j-to-slf4j`: `spring-boot-starter-logging`(기본 logback 백엔드)에서 제공 — 정상
- `log4j-slf4j2-impl`: `egovframe-cloud-module-common` → `egovframe-rte-fdl-cmmn` → `egovframe-rte-fdl-logging` 경로로 유입

직접 의존인 `egovframe-rte-fdl-cmmn`에는 이미 `egovframe-rte-fdl-logging` 제외가 적용되어 있으나, `egovframe-cloud-module-common`을 경유하는 전이 의존에는 동일 제외가 누락되어 있었습니다.

## 변경 내용

`egovframe-cloud-module-common` 의존에도 `egovframe-rte-fdl-logging` 제외를 추가했습니다(기존 패턴과 동일). logback(`log4j-to-slf4j`) 단일 바인딩으로 정리됩니다.

## 검증

- `testRuntimeClasspath`에서 `log4j-slf4j2-impl`이 더 이상 해석되지 않음을 `dependencyInsight`로 확인
- SLF4J 로거 초기화 스모크 테스트(`LoggingBindingSmokeTest`) 통과 — 수정 전에는 동일 테스트가 `LoggingException`으로 실패
