### PR TITLE
fix: 나머지 서비스 log4j 이중 바인딩 충돌 제거 (#66 후속)

### DIFF
--- a/backend/board-service/build.gradle
+++ b/backend/board-service/build.gradle
@@ -29,6 +29,9 @@ ext {
 dependencies {
 //    implementation files('../module-common/build/libs/egovframe-cloud-module-common.jar') // @ComponentScan(basePackages={"org.egovframe.cloud"}) 추가해야 적용된다
     implementation("org.egovframe.cloud:egovframe-cloud-module-common:${egovframeBootParentVersion}") {
+        // egovframe-rte-fdl-logging이 log4j-slf4j2-impl(slf4j→log4j2)을 끌어와
+        // Spring Boot 기본 logback의 log4j-to-slf4j(log4j2→slf4j)와 충돌하므로 제외한다.
+        exclude group: 'org.egovframe.rte', module: 'egovframe-rte-fdl-logging'
         exclude group: 'commons-logging', module: 'commons-logging'
     }
     implementation("org.egovframe.rte:egovframe-rte-fdl-cmmn:${egovframeBootParentVersion}") {

--- a/backend/reserve-check-service/build.gradle
+++ b/backend/reserve-check-service/build.gradle
@@ -29,6 +29,9 @@ ext {
 dependencies {
 //    implementation files('../module-common/build/libs/egovframe-cloud-module-common.jar') // @ComponentScan(basePackages={"org.egovframe.cloud"}) 추가해야 적용된다
     implementation("org.egovframe.cloud:egovframe-cloud-module-common:${egovframeBootParentVersion}") {
+        // egovframe-rte-fdl-logging이 log4j-slf4j2-impl(slf4j→log4j2)을 끌어와
+        // Spring Boot 기본 logback의 log4j-to-slf4j(log4j2→slf4j)와 충돌하므로 제외한다.
+        exclude group: 'org.egovframe.rte', module: 'egovframe-rte-fdl-logging'
         exclude group: 'commons-logging', module: 'commons-logging'
     }
     implementation("org.egovframe.rte:egovframe-rte-fdl-cmmn:${egovframeBootParentVersion}") {

--- a/backend/reserve-request-service/build.gradle
+++ b/backend/reserve-request-service/build.gradle
@@ -28,6 +28,9 @@ ext {
 dependencies {
 //    implementation files('../module-common/build/libs/egovframe-cloud-module-common.jar') // @ComponentScan(basePackages={"org.egovframe.cloud"}) 추가해야 적용된다
     implementation("org.egovframe.cloud:egovframe-cloud-module-common:${egovframeBootParentVersion}") {
+        // egovframe-rte-fdl-logging이 log4j-slf4j2-impl(slf4j→log4j2)을 끌어와
+        // Spring Boot 기본 logback의 log4j-to-slf4j(log4j2→slf4j)와 충돌하므로 제외한다.
+        exclude group: 'org.egovframe.rte', module: 'egovframe-rte-fdl-logging'
         exclude group: 'commons-logging', module: 'commons-logging'
     }
     implementation("org.egovframe.rte:egovframe-rte-fdl-cmmn:${egovframeBootParentVersion}") {

--- a/backend/user-service/build.gradle
+++ b/backend/user-service/build.gradle
@@ -30,6 +30,9 @@ ext {
 dependencies {
 //    implementation files('../module-common/build/libs/egovframe-cloud-module-common.jar') // @ComponentScan(basePackages={"org.egovframe.cloud"}) 추가해야 적용된다
     implementation("org.egovframe.cloud:egovframe-cloud-module-common:${egovframeBootParentVersion}") {
+        // egovframe-rte-fdl-logging이 log4j-slf4j2-impl(slf4j→log4j2)을 끌어와
+        // Spring Boot 기본 logback의 log4j-to-slf4j(log4j2→slf4j)와 충돌하므로 제외한다.
+        exclude group: 'org.egovframe.rte', module: 'egovframe-rte-fdl-logging'
         exclude group: 'commons-logging', module: 'commons-logging'
     }
     implementation("org.egovframe.rte:egovframe-rte-fdl-cmmn:${egovframeBootParentVersion}") {

--- a/backend/user-service/src/test/java/org/egovframe/cloud/userservice/LoggingBindingSmokeTest.java
+++ b/backend/user-service/src/test/java/org/egovframe/cloud/userservice/LoggingBindingSmokeTest.java
@@ -1,0 +1,26 @@
+package org.egovframe.cloud.userservice;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * SLF4J 바인딩이 단일(logback)임을 검증한다.
+ *
+ * <p>egovframe-rte-fdl-logging이 끌어오던 log4j-slf4j2-impl과 Spring Boot 기본
+ * logback의 log4j-to-slf4j가 동시에 존재하면 로거 초기화 시
+ * {@code LoggingException: log4j-slf4j2-impl cannot be present with log4j-to-slf4j}가
+ * 발생한다. 이 테스트는 로거 초기화가 예외 없이 수행되는지 확인한다.</p>
+ */
+class LoggingBindingSmokeTest {
+
+    @Test
+    void slf4jLoggerInitializesWithoutLog4jConflict() {
+        assertDoesNotThrow(() -> {
+            Logger log = LoggerFactory.getLogger(LoggingBindingSmokeTest.class);
+            log.info("logging smoke");
+        });
+    }
+}


### PR DESCRIPTION
## 개요

[#66](https://github.com/eGovFramework/egovframe-msa-edu/pull/66)에서 portal-service의 log4j 이중 바인딩 충돌을 수정했는데, 동일한 문제가 다른 서비스에도 존재합니다.

```
org.apache.logging.log4j.LoggingException: log4j-slf4j2-impl cannot be present with log4j-to-slf4j
```

## 원인

각 서비스에서 `egovframe-cloud-module-common` → `egovframe-rte-fdl-cmmn` → `egovframe-rte-fdl-logging` 경로로 `log4j-slf4j2-impl`(slf4j→log4j2 바인딩)이 유입되어, Spring Boot 기본 logback이 제공하는 `log4j-to-slf4j`(log4j2→slf4j)와 동시에 존재합니다. 직접 의존인 `egovframe-rte-fdl-cmmn`에는 이미 `egovframe-rte-fdl-logging` 제외가 적용되어 있으나, `egovframe-cloud-module-common` 경유 전이 의존에는 누락되어 있었습니다.

## 변경 내용

다음 4개 서비스의 `egovframe-cloud-module-common` 의존에 `egovframe-rte-fdl-logging` 제외를 추가했습니다.

- user-service
- board-service
- reserve-request-service
- reserve-check-service

## 검증

- 4개 서비스 모두 `testRuntimeClasspath`에서 `log4j-slf4j2-impl`이 더 이상 해석되지 않음을 `dependencyInsight`로 확인
- user-service에 SLF4J 로거 초기화 스모크 테스트(`LoggingBindingSmokeTest`) 추가 — 통과
