### PR TITLE
[test][msa-edu] reserve-check-service ReserveStatus·Category enum 단위 테스트 추가

### DIFF
--- a/backend/reserve-check-service/src/test/java/org/egovframe/cloud/reservechecksevice/domain/CategoryTest.java
+++ b/backend/reserve-check-service/src/test/java/org/egovframe/cloud/reservechecksevice/domain/CategoryTest.java
@@ -1,0 +1,45 @@
+package org.egovframe.cloud.reservechecksevice.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CategoryTest {
+
+    @Test
+    @DisplayName("각 예약 유형의 key와 title이 정확하게 정의된다")
+    void 예약_유형_key_title_검증() {
+        assertThat(Category.EDUCATION.getKey()).isEqualTo("education");
+        assertThat(Category.EDUCATION.getTitle()).isEqualTo("교육");
+
+        assertThat(Category.EQUIPMENT.getKey()).isEqualTo("equipment");
+        assertThat(Category.EQUIPMENT.getTitle()).isEqualTo("장비");
+
+        assertThat(Category.SPACE.getKey()).isEqualTo("space");
+        assertThat(Category.SPACE.getTitle()).isEqualTo("공간");
+    }
+
+    @Test
+    @DisplayName("isEquals는 key 문자열이 일치할 때 true를 반환한다")
+    void isEquals_일치하는_key_true반환() {
+        assertThat(Category.EDUCATION.isEquals("education")).isTrue();
+        assertThat(Category.EQUIPMENT.isEquals("equipment")).isTrue();
+        assertThat(Category.SPACE.isEquals("space")).isTrue();
+    }
+
+    @Test
+    @DisplayName("isEquals는 key 문자열이 다를 때 false를 반환한다")
+    void isEquals_다른_key_false반환() {
+        assertThat(Category.EDUCATION.isEquals("equipment")).isFalse();
+        assertThat(Category.EDUCATION.isEquals("EDUCATION")).isFalse();
+        assertThat(Category.EQUIPMENT.isEquals("space")).isFalse();
+        assertThat(Category.SPACE.isEquals("")).isFalse();
+    }
+
+    @Test
+    @DisplayName("전체 enum 상수 개수는 3개이다")
+    void 예약_유형_상수_개수_검증() {
+        assertThat(Category.values()).hasSize(3);
+    }
+}

--- a/backend/reserve-check-service/src/test/java/org/egovframe/cloud/reservechecksevice/domain/ReserveStatusTest.java
+++ b/backend/reserve-check-service/src/test/java/org/egovframe/cloud/reservechecksevice/domain/ReserveStatusTest.java
@@ -1,0 +1,49 @@
+package org.egovframe.cloud.reservechecksevice.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ReserveStatusTest {
+
+    @Test
+    @DisplayName("각 예약 상태의 key와 title이 정확하게 정의된다")
+    void 예약_상태_key_title_검증() {
+        assertThat(ReserveStatus.REQUEST.getKey()).isEqualTo("request");
+        assertThat(ReserveStatus.REQUEST.getTitle()).isEqualTo("예약 신청");
+
+        assertThat(ReserveStatus.APPROVE.getKey()).isEqualTo("approve");
+        assertThat(ReserveStatus.APPROVE.getTitle()).isEqualTo("예약 승인");
+
+        assertThat(ReserveStatus.CANCEL.getKey()).isEqualTo("cancel");
+        assertThat(ReserveStatus.CANCEL.getTitle()).isEqualTo("예약 취소");
+
+        assertThat(ReserveStatus.DONE.getKey()).isEqualTo("done");
+        assertThat(ReserveStatus.DONE.getTitle()).isEqualTo("완료");
+    }
+
+    @Test
+    @DisplayName("isEquals는 key 문자열이 일치할 때 true를 반환한다")
+    void isEquals_일치하는_key_true반환() {
+        assertThat(ReserveStatus.REQUEST.isEquals("request")).isTrue();
+        assertThat(ReserveStatus.APPROVE.isEquals("approve")).isTrue();
+        assertThat(ReserveStatus.CANCEL.isEquals("cancel")).isTrue();
+        assertThat(ReserveStatus.DONE.isEquals("done")).isTrue();
+    }
+
+    @Test
+    @DisplayName("isEquals는 key 문자열이 다를 때 false를 반환한다")
+    void isEquals_다른_key_false반환() {
+        assertThat(ReserveStatus.REQUEST.isEquals("approve")).isFalse();
+        assertThat(ReserveStatus.REQUEST.isEquals("cancel")).isFalse();
+        assertThat(ReserveStatus.REQUEST.isEquals("REQUEST")).isFalse();
+        assertThat(ReserveStatus.REQUEST.isEquals("")).isFalse();
+    }
+
+    @Test
+    @DisplayName("전체 enum 상수 개수는 4개이다")
+    void 예약_상태_상수_개수_검증() {
+        assertThat(ReserveStatus.values()).hasSize(4);
+    }
+}


### PR DESCRIPTION
## 개요

reserve-check-service 도메인의 `ReserveStatus`·`Category` enum 동작(코드/명칭 매핑 등)에 대한 순수 단위 테스트를 추가합니다.

## 변경 사항

- `CategoryTest.java`, `ReserveStatusTest.java` (신규, +94)

## 검증

- `./gradlew :reserve-check-service:compileTestJava` BUILD SUCCESSFUL

> 기존 #56을 대체합니다. #56에는 테스트와 무관한 보안 커밋(이미 main에 반영된 `국정원 보안점검`)이 섞여 있어, 테스트 커밋만 담아 재제출합니다.
