### PR TITLE
[chore][msa-edu] board-service logback-spring.xml RollingFile Appender 추가

### DIFF
--- a/backend/board-service/src/main/resources/logback-spring.xml
+++ b/backend/board-service/src/main/resources/logback-spring.xml
@@ -40,9 +40,43 @@
                 </providers>
             </encoder>
         </appender>
+
+        <!-- RollingFile - JSON 구조화 로그를 파일로 기록 (운영 환경 장애 분석용) -->
+        <property name="LOG_PATH" value="${log_path:-./logs}" />
+        <appender name="ROLLING_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>${LOG_PATH}/${app_name}.log</file>
+            <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+                <fileNamePattern>${LOG_PATH}/${app_name}.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+                <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                    <maxFileSize>100MB</maxFileSize>
+                </timeBasedFileNamingAndTriggeringPolicy>
+                <maxHistory>30</maxHistory>
+                <totalSizeCap>3GB</totalSizeCap>
+            </rollingPolicy>
+            <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+                <providers>
+                    <timestamp>
+                        <fieldName>timestamp</fieldName>
+                        <pattern>yyyy-MM-dd'T'HH:mm:ss.SSSZ</pattern>
+                    </timestamp>
+                    <logLevel/>
+                    <loggerName/>
+                    <mdc/>
+                    <pattern>
+                        <pattern>
+                            {"appName": "${app_name}"}
+                        </pattern>
+                    </pattern>
+                    <threadName/>
+                    <message/>
+                    <stackTrace/>
+                </providers>
+            </encoder>
+        </appender>
         <root level="WARN">
             <appender-ref ref="LOGSTASH" />
             <appender-ref ref="STDOUT" />
+            <appender-ref ref="ROLLING_FILE" />
         </root>
     </springProfile>
 


### PR DESCRIPTION
## 개요

board-service의 운영 로깅을 위해 `logback-spring.xml`에 RollingFile Appender(시간/크기 기반 롤링, JSON 인코딩 옵션)를 추가합니다.

## 변경 사항

- `backend/board-service/src/main/resources/logback-spring.xml` (+34)

## 검증

- `xmllint --noout` XML 문법 OK
- 단일 설정 파일 추가로 기존 동작 영향 없음

> 기존 #53을 대체합니다. #53에는 로깅과 무관한 보안 커밋(이미 main에 반영된 `국정원 보안점검`)이 섞여 있어, 로깅 설정 커밋만 담아 재제출합니다.
