### PR TITLE
[ci][msa-edu] Gradle·Actions·Docker Dependabot 설정 추가

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,64 @@
+version: 2
+updates:
+  # Gradle backend modules
+  - package-ecosystem: "gradle"
+    directories:
+      - "/backend/apigateway"
+      - "/backend/board-service"
+      - "/backend/config"
+      - "/backend/discovery"
+      - "/backend/egovframe-cloud-module-common"
+      - "/backend/portal-service"
+      - "/backend/reserve-check-service"
+      - "/backend/reserve-item-service"
+      - "/backend/reserve-request-service"
+      - "/backend/user-service"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Seoul"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Seoul"
+    open-pull-requests-limit: 3
+    labels:
+      - "ci"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+
+  # Docker images (Dockerfile, DockerfileK8s under each backend service)
+  - package-ecosystem: "docker"
+    directories:
+      - "/backend/apigateway"
+      - "/backend/board-service"
+      - "/backend/config"
+      - "/backend/discovery"
+      - "/backend/portal-service"
+      - "/backend/reserve-check-service"
+      - "/backend/reserve-item-service"
+      - "/backend/reserve-request-service"
+      - "/backend/user-service"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Seoul"
+    open-pull-requests-limit: 5
+    labels:
+      - "docker"
+    commit-message:
+      prefix: "docker"
+      include: "scope"


### PR DESCRIPTION
## 개요

Gradle(백엔드 8개 서비스)·GitHub Actions·Docker 대상 Dependabot 설정을 추가해 의존성 보안 업데이트를 자동화합니다.

## 변경 사항

- `.github/dependabot.yml` (신규, +64)

> 기존 #43을 대체합니다. #43에는 무관한 보안 커밋(이미 main 반영된 `국정원 보안점검`)이 섞여 있어, 설정 커밋만 담아 재제출합니다.
