### PR TITLE
[feat][msa-edu] backend 9개 Deployment 프로브·리소스·securityContext 추가

### DIFF
--- a/k8s/applications/backend/apigateway/deployment.yaml
+++ b/k8s/applications/backend/apigateway/deployment.yaml
@@ -25,6 +25,11 @@ spec:
         app: apigateway
         name: apigateway-pod
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       containers:
         - name: apigateway
           image: egovframe/egovframe-msa-edu-backend-apigateway:latest # TODO
@@ -67,4 +72,25 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
             successThreshold: 1
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8000
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "512Mi"
+            limits:
+              cpu: "1000m"
+              memory: "1Gi"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
             failureThreshold: 3

--- a/k8s/applications/backend/board-service/deployment.yaml
+++ b/k8s/applications/backend/board-service/deployment.yaml
@@ -25,6 +25,11 @@ spec:
         app: board-service
         name: board-service-pod
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       tolerations:
         - key: pvc
           operator: Equal
@@ -90,6 +95,27 @@ spec:
             periodSeconds: 10
             successThreshold: 1
             failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 80
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "512Mi"
+            limits:
+              cpu: "1000m"
+              memory: "1Gi"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           volumeMounts:
             - name: backend-volume
               mountPath: /srv/nfs

--- a/k8s/applications/backend/config/deployment.yaml
+++ b/k8s/applications/backend/config/deployment.yaml
@@ -25,6 +25,11 @@ spec:
         app: config
         name: config-pod
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       containers:
         - name: config
           image: egovframe/egovframe-msa-edu-backend-config:latest # TODO
@@ -56,4 +61,25 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 10
             successThreshold: 1
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8888
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "512Mi"
+            limits:
+              cpu: "1000m"
+              memory: "1Gi"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
             failureThreshold: 3

--- a/k8s/applications/backend/discovery/deployment.yaml
+++ b/k8s/applications/backend/discovery/deployment.yaml
@@ -25,6 +25,11 @@ spec:
         app: discovery
         name: discovery-pod
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       containers:
         - name: discovery
           image: egovframe/egovframe-msa-edu-backend-discovery:latest # TODO
@@ -46,4 +51,25 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
             successThreshold: 1
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8761
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "512Mi"
+            limits:
+              cpu: "1000m"
+              memory: "1Gi"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
             failureThreshold: 3

--- a/k8s/applications/backend/portal-service/deployment.yaml
+++ b/k8s/applications/backend/portal-service/deployment.yaml
@@ -25,6 +25,11 @@ spec:
         app: portal-service
         name: portal-service-pod
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       tolerations:
         - key: pvc
           operator: Equal
@@ -90,6 +95,27 @@ spec:
             periodSeconds: 10
             successThreshold: 1
             failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 80
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "512Mi"
+            limits:
+              cpu: "1000m"
+              memory: "1Gi"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           volumeMounts:
             - name: backend-volume
               mountPath: /srv/nfs

--- a/k8s/applications/backend/reserve-check-service/deployment.yaml
+++ b/k8s/applications/backend/reserve-check-service/deployment.yaml
@@ -25,6 +25,11 @@ spec:
         app: reserve-check-service
         name: reserve-check-service-pod
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       containers:
         - name: reserve-check-service
           image: egovframe/egovframe-msa-edu-backend-reserve-check-service:latest # TODO
@@ -84,4 +89,25 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
             successThreshold: 1
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 80
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "512Mi"
+            limits:
+              cpu: "1000m"
+              memory: "1Gi"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
             failureThreshold: 3

--- a/k8s/applications/backend/reserve-item-service/deployment.yaml
+++ b/k8s/applications/backend/reserve-item-service/deployment.yaml
@@ -25,6 +25,11 @@ spec:
         app: reserve-item-service
         name: reserve-item-service-pod
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       containers:
         - name: reserve-item-service
           image: egovframe/egovframe-msa-edu-backend-reserve-item-service:latest # TODO
@@ -84,4 +89,25 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
             successThreshold: 1
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 80
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "512Mi"
+            limits:
+              cpu: "1000m"
+              memory: "1Gi"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
             failureThreshold: 3

--- a/k8s/applications/backend/reserve-request-service/deployment.yaml
+++ b/k8s/applications/backend/reserve-request-service/deployment.yaml
@@ -25,6 +25,11 @@ spec:
         app: reserve-request-service
         name: reserve-request-service-pod
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       containers:
         - name: reserve-request-service
           image: egovframe/egovframe-msa-edu-backend-reserve-request-service:latest # TODO
@@ -84,4 +89,25 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
             successThreshold: 1
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 80
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "512Mi"
+            limits:
+              cpu: "1000m"
+              memory: "1Gi"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
             failureThreshold: 3

--- a/k8s/applications/backend/user-service/deployment.yaml
+++ b/k8s/applications/backend/user-service/deployment.yaml
@@ -25,6 +25,11 @@ spec:
         app: user-service
         name: user-service-pod
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       containers:
         - name: user-service
           image: egovframe/egovframe-msa-edu-backend-user-service:latest # TODO
@@ -84,4 +89,25 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
             successThreshold: 1
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 80
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "512Mi"
+            limits:
+              cpu: "1000m"
+              memory: "1Gi"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
             failureThreshold: 3


### PR DESCRIPTION
## 개요

backend 9개 서비스 Deployment에 운영 안정성 강화 설정(livenessProbe/readinessProbe, resources requests·limits, securityContext)을 추가합니다.

## 변경 사항

- `k8s/applications/backend/*/deployment.yaml` 9개 (apigateway·board·config·discovery·portal·reserve-check·reserve-item·reserve-request·user)

## 참고

- 프로브 경로/포트·리소스 한계는 각 서비스 기동 특성에 맞춰 조정이 필요할 수 있어, 실 클러스터 검증 시 확인 부탁드립니다.

> 기존 #44를 대체합니다. #44에는 무관한 보안 커밋(이미 main 반영된 `국정원 보안점검`)이 섞여 있어, k8s 하드닝 커밋만 담아 재제출합니다.
