### PR TITLE
[ci][msa-edu] 백엔드·프론트엔드 빌드 GitHub Actions 워크플로 신설

### DIFF
--- a/.github/workflows/build-backend.yml
+++ b/.github/workflows/build-backend.yml
@@ -1,0 +1,43 @@
+name: Backend Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        service:
+          - apigateway
+          - board-service
+          - config
+          - discovery
+          - egovframe-cloud-module-common
+          - portal-service
+          - reserve-check-service
+          - reserve-item-service
+          - reserve-request-service
+          - user-service
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: Build ${{ matrix.service }}
+        run: cd backend/${{ matrix.service }} && ./gradlew --no-daemon build -x test

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -1,0 +1,38 @@
+name: Frontend Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        app:
+          - admin
+          - portal
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: frontend/${{ matrix.app }}/package-lock.json
+
+      - name: Install dependencies
+        run: cd frontend/${{ matrix.app }} && npm ci
+
+      - name: Build ${{ matrix.app }}
+        run: cd frontend/${{ matrix.app }} && npm run build --if-present


### PR DESCRIPTION
## 개요

백엔드(Gradle 매트릭스)·프론트엔드 빌드 검증용 GitHub Actions 워크플로를 신설합니다.

## 변경 사항

- `.github/workflows/build-backend.yml`, `build-frontend.yml` (신규)
- `actions/checkout@v4`, `actions/setup-java@v4`(temurin, JDK 17)
- 트리거는 `main`만 지정(버전 브랜치 필터는 PR이 base 브랜치의 워크플로를 읽는 구조상 무효라 제외)

> 기존 #45를 대체합니다. #45에는 무관한 보안 커밋(이미 main 반영된 `국정원 보안점검`)이 섞여 있고 트리거에 무효한 `5.0.x` 필터가 있어, 워크플로 커밋만 담고 트리거를 main으로 정리해 재제출합니다.
