### PR TITLE
fix: reserve-check-service 예약 재고 검증 조건 오류 수정

### DIFF
--- a/backend/reserve-check-service/src/main/java/org/egovframe/cloud/reservechecksevice/domain/ReserveValidator.java
+++ b/backend/reserve-check-service/src/main/java/org/egovframe/cloud/reservechecksevice/domain/ReserveValidator.java
@@ -107,7 +107,7 @@ public class ReserveValidator {
                     return Mono.error(new BusinessMessageException(getMessage("valid.reserve_close")));
                 }
 
-                if (reserveItemResponseDto.isPossibleInventoryQty(reserve.getReserveQty())) {
+                if (!reserveItemResponseDto.isPossibleInventoryQty(reserve.getReserveQty())) {
                     //예약가능한 인원이 부족합니다. (남은 인원 : {0})
                     return Mono.error(new BusinessMessageException(getMessage("valid.reserve_number_of_people", new Object[]{reserveItemResponseDto.getInventoryQty()})));
                 }
@@ -216,17 +216,11 @@ public class ReserveValidator {
      * @return
      */
     private Mono<Integer> countMax(Flux<Reserve> reserveFlux, LocalDateTime startDate, LocalDateTime endDate) {
-        if (reserveFlux.equals(Flux.empty())) {
-            return Mono.just(0);
-        }
-
         long between = ChronoUnit.DAYS.between(startDate, endDate);
 
         if (between == 0) {
             return reserveFlux.map(reserve -> {
-                if (startDate.isAfter(reserve.getReserveStartDate())
-                    || startDate.isBefore(reserve.getReserveEndDate())
-                    || startDate.isEqual(reserve.getReserveStartDate()) || startDate.isEqual(reserve.getReserveEndDate())) {
+                if (isOverlapped(startDate, reserve)) {
                     return reserve.getReserveQty();
                 }
                 return 0;
@@ -238,9 +232,7 @@ public class ReserveValidator {
             .mapToObj(i -> startDate.plusDays(i)))
             .flatMap(localDateTime ->
                 reserveFlux.map(findReserve -> {
-                    if (localDateTime.isAfter(findReserve.getReserveStartDate())
-                        || localDateTime.isBefore(findReserve.getReserveEndDate())
-                        || localDateTime.isEqual(findReserve.getReserveStartDate()) || localDateTime.isEqual(findReserve.getReserveEndDate())) {
+                    if (isOverlapped(localDateTime, findReserve)) {
                         return findReserve.getReserveQty();
                     }
                     return 0;
@@ -248,6 +240,18 @@ public class ReserveValidator {
             .groupBy(integer -> integer)
             .flatMap(group -> group.reduce((x1,x2) -> x1 > x2?x1:x2))
             .last(0);
+    }
+
+    /**
+     * 조회 날짜가 예약 기간(시작일~종료일, 양 끝 포함)에 겹치는지 판단한다.
+     *
+     * @param date 조회 날짜
+     * @param reserve 비교 대상 예약
+     * @return 겹치면 true
+     */
+    private boolean isOverlapped(LocalDateTime date, Reserve reserve) {
+        return !date.isBefore(reserve.getReserveStartDate())
+            && !date.isAfter(reserve.getReserveEndDate());
     }
 
     private String getMessage(String code) {

--- a/backend/reserve-check-service/src/test/java/org/egovframe/cloud/reservechecksevice/domain/ReserveValidatorCountMaxTest.java
+++ b/backend/reserve-check-service/src/test/java/org/egovframe/cloud/reservechecksevice/domain/ReserveValidatorCountMaxTest.java
@@ -1,0 +1,93 @@
+package org.egovframe.cloud.reservechecksevice.domain;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+import org.egovframe.cloud.reservechecksevice.client.ReserveItemServiceClient;
+
+/**
+ * org.egovframe.cloud.reservechecksevice.domain.ReserveValidatorCountMaxTest
+ *
+ * 예약 일자 겹침 기준 최대 사용량(countMax) 판정 단위 테스트.
+ * 조회 날짜와 겹치지 않는 예약이 사용량에 합산되지 않아야 한다.
+ *
+ * @author 표준프레임워크센터
+ * @version 1.0
+ */
+class ReserveValidatorCountMaxTest {
+
+    private ReserveRepository reserveRepository;
+    private ReserveValidator reserveValidator;
+
+    private static final LocalDateTime QUERY_DATE = LocalDateTime.of(2026, 6, 1, 10, 0);
+
+    @BeforeEach
+    void setUp() {
+        reserveRepository = mock(ReserveRepository.class);
+        ReserveItemServiceClient reserveItemServiceClient = mock(ReserveItemServiceClient.class);
+        CircuitBreakerRegistry circuitBreakerRegistry = mock(CircuitBreakerRegistry.class);
+        reserveValidator = new ReserveValidator(reserveRepository, reserveItemServiceClient, circuitBreakerRegistry);
+    }
+
+    private Reserve reserve(LocalDateTime start, LocalDateTime end, int qty) {
+        return Reserve.builder()
+            .reserveItemId(1L)
+            .reserveStartDate(start)
+            .reserveEndDate(end)
+            .reserveQty(qty)
+            .build();
+    }
+
+    @Test
+    @DisplayName("조회 날짜와 겹치지 않는 예약은 사용량에 합산되지 않는다")
+    void nonOverlappingReservationIsNotCounted() {
+        // 예약 기간(5/1~5/2)이 조회 날짜(6/1)보다 모두 과거라 겹치지 않는다.
+        when(reserveRepository.findAllByReserveDate(anyLong(), any(), any()))
+            .thenReturn(Flux.just(reserve(
+                LocalDateTime.of(2026, 5, 1, 0, 0),
+                LocalDateTime.of(2026, 5, 2, 0, 0),
+                5)));
+
+        StepVerifier.create(reserveValidator.getMaxByReserveDate(1L, QUERY_DATE, QUERY_DATE))
+            .expectNext(0)
+            .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("조회 날짜와 겹치는 예약은 사용량에 합산된다")
+    void overlappingReservationIsCounted() {
+        // 예약 기간(5/30~6/2)이 조회 날짜(6/1)를 포함하여 겹친다.
+        when(reserveRepository.findAllByReserveDate(anyLong(), any(), any()))
+            .thenReturn(Flux.just(reserve(
+                LocalDateTime.of(2026, 5, 30, 0, 0),
+                LocalDateTime.of(2026, 6, 2, 0, 0),
+                5)));
+
+        StepVerifier.create(reserveValidator.getMaxByReserveDate(1L, QUERY_DATE, QUERY_DATE))
+            .expectNext(5)
+            .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("예약이 없으면 사용량은 0이다")
+    void emptyReservationsCountsZero() {
+        when(reserveRepository.findAllByReserveDate(anyLong(), any(), any()))
+            .thenReturn(Flux.empty());
+
+        StepVerifier.create(reserveValidator.getMaxByReserveDate(1L, QUERY_DATE, QUERY_DATE))
+            .expectNext(0)
+            .verifyComplete();
+    }
+}

--- a/backend/reserve-check-service/src/test/java/org/egovframe/cloud/reservechecksevice/domain/ReserveValidatorEducationTest.java
+++ b/backend/reserve-check-service/src/test/java/org/egovframe/cloud/reservechecksevice/domain/ReserveValidatorEducationTest.java
@@ -1,0 +1,115 @@
+package org.egovframe.cloud.reservechecksevice.domain;
+
+import static org.mockito.Mockito.mock;
+
+import java.time.LocalDateTime;
+
+import org.egovframe.cloud.common.exception.BusinessMessageException;
+import org.egovframe.cloud.common.util.MessageUtil;
+import org.egovframe.cloud.reservechecksevice.client.ReserveItemServiceClient;
+import org.egovframe.cloud.reservechecksevice.client.dto.ReserveItemResponseDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import reactor.test.StepVerifier;
+
+/**
+ * org.egovframe.cloud.reservechecksevice.domain.ReserveValidatorEducationTest
+ *
+ * 교육 예약 재고 검증(checkEducation) 단위 테스트
+ *
+ * @author 표준프레임워크센터
+ * @version 1.0
+ */
+class ReserveValidatorEducationTest {
+
+    private ReserveValidator reserveValidator;
+
+    @BeforeEach
+    void setUp() {
+        MessageUtil messageUtil = mock(MessageUtil.class);
+        BDDMockito.given(messageUtil.getMessage(BDDMockito.anyString()))
+            .willReturn("message");
+        BDDMockito.given(messageUtil.getMessage(BDDMockito.anyString(), BDDMockito.any()))
+            .willReturn("message");
+
+        ReserveRepository reserveRepository = mock(ReserveRepository.class);
+        ReserveItemServiceClient reserveItemServiceClient = mock(ReserveItemServiceClient.class);
+        CircuitBreakerRegistry circuitBreakerRegistry = mock(CircuitBreakerRegistry.class);
+
+        reserveValidator = new ReserveValidator(reserveRepository, reserveItemServiceClient, circuitBreakerRegistry);
+        setField(reserveValidator, "messageUtil", messageUtil);
+    }
+
+    /** 순수 리플렉션으로 비공개 필드를 주입한다(테스트 인프라 로깅 초기화 의존 회피). */
+    private static void setField(Object target, String name, Object value) {
+        try {
+            java.lang.reflect.Field field = target.getClass().getDeclaredField(name);
+            field.setAccessible(true);
+            field.set(target, value);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private ReserveItemResponseDto educationItem(int inventoryQty) {
+        LocalDateTime now = LocalDateTime.now();
+        ReserveItem reserveItem = ReserveItem.builder()
+            .reserveItemId(1L)
+            .categoryId("education")
+            .totalQty(100)
+            .inventoryQty(inventoryQty)
+            .reserveMeansId("realtime")
+            .requestStartDate(now.minusDays(1))
+            .requestEndDate(now.plusDays(1))
+            .operationStartDate(now.minusDays(1))
+            .operationEndDate(now.plusDays(1))
+            .build();
+        return ReserveItemResponseDto.builder().reserveItem(reserveItem).build();
+    }
+
+    private Reserve reserve(int reserveQty) {
+        return Reserve.builder()
+            .reserveId("reserve-1")
+            .reserveItemId(1L)
+            .categoryId("education")
+            .reserveQty(reserveQty)
+            .build();
+    }
+
+    @Test
+    @DisplayName("재고(수용인원)가 신청 인원 이상이면 예약을 통과시킨다")
+    void checkEducation_재고충분_통과() {
+        ReserveItemResponseDto reserveItem = educationItem(10);
+        Reserve reserve = reserve(5);
+
+        StepVerifier.create(reserveValidator.checkEducation(reserveItem, reserve))
+            .expectNext(reserve)
+            .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("재고(수용인원)가 신청 인원과 같으면 예약을 통과시킨다")
+    void checkEducation_재고동일_통과() {
+        ReserveItemResponseDto reserveItem = educationItem(5);
+        Reserve reserve = reserve(5);
+
+        StepVerifier.create(reserveValidator.checkEducation(reserveItem, reserve))
+            .expectNext(reserve)
+            .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("재고(수용인원)가 신청 인원보다 적으면 인원 부족 오류가 발생한다")
+    void checkEducation_재고부족_오류() {
+        ReserveItemResponseDto reserveItem = educationItem(3);
+        Reserve reserve = reserve(5);
+
+        StepVerifier.create(reserveValidator.checkEducation(reserveItem, reserve))
+            .expectError(BusinessMessageException.class)
+            .verify();
+    }
+}


### PR DESCRIPTION
## 변경 이유

`reserve-check-service`의 `ReserveValidator`에 예약 재고 검증 조건 오류가 두 군데 있습니다. 동일 검증을 수행하는 `reserve-request-service`의 로직과 대조해 확인했습니다.

**1) checkEducation — 재고 판정 반전**

```java
if (reserveItemResponseDto.isPossibleInventoryQty(reserve.getReserveQty())) {
    return Mono.error(... 인원 부족 ...);
}
```

`isPossibleInventoryQty`는 `inventoryQty >= reserveQty`로 **재고가 충분하면 true**입니다(`ReserveItemResponseDto`). 그런데 부정 없이 오류 조건으로 사용해, 재고가 충분하면 거부하고 부족하면 통과하는 정반대 동작이 됩니다.

**2) countMax — 일자 겹침 판정이 항상 참**

```java
if (startDate.isAfter(s) || startDate.isBefore(e) || startDate.isEqual(s) || startDate.isEqual(e))
```

OR 결합이라 사실상 항상 참이 되어, 조회 기간과 겹치지 않는 예약까지 사용 수량에 합산됩니다. 또한 `if (reserveFlux.equals(Flux.empty()))`는 항상 거짓이라 실행되지 않는 dead branch입니다.

## 변경 내용

- checkEducation: 재고 부족(`!isPossibleInventoryQty`)일 때만 오류를 반환하도록 교정.
- countMax: 기간 양 끝을 포함한 겹침 판정(`!date.isBefore(start) && !date.isAfter(end)`)으로 교정하고 dead branch 제거.

## 테스트 방법

`ReserveValidatorEducationTest`(3건)·`ReserveValidatorCountMaxTest`(3건):
- 재고가 신청 인원 이상/동일이면 통과, 부족이면 오류
- 조회 날짜와 겹치지 않는 예약은 합산되지 않고, 겹치는 예약만 합산, 예약이 없으면 0

`MockitoExtension` 없이 순수 리플렉션으로 의존을 주입해 외부 인프라 없이 검증합니다.

## 영향 범위

`ReserveValidator`의 재고·일자 검증만 변경합니다.
