### PR TITLE
fix: reserve-request-service 예약 일자 겹침 판정 오류로 인한 재고 과대 계산 수정

### DIFF
--- a/backend/reserve-request-service/src/main/java/org/egovframe/cloud/reserverequestservice/domain/ReserveValidator.java
+++ b/backend/reserve-request-service/src/main/java/org/egovframe/cloud/reserverequestservice/domain/ReserveValidator.java
@@ -130,20 +130,13 @@ public class ReserveValidator {
      * @return
      */
     private Mono<Integer> getMaxByReserveDate( Long reserveItemId, LocalDateTime startDate, LocalDateTime endDate) {
-        Flux<Reserve> reserveFlux = reserveRepository.findAllByReserveDate(reserveItemId, startDate, endDate)
-            .switchIfEmpty(Flux.empty());
-
-        if (reserveFlux.equals(Flux.empty())) {
-            return Mono.just(0);
-        }
+        Flux<Reserve> reserveFlux = reserveRepository.findAllByReserveDate(reserveItemId, startDate, endDate);
 
         long between = ChronoUnit.DAYS.between(startDate, endDate);
 
         if (between == 0) {
             return reserveFlux.map(reserve -> {
-                if (startDate.isAfter(reserve.getReserveStartDate())
-                    || startDate.isBefore(reserve.getReserveEndDate())
-                    || startDate.isEqual(reserve.getReserveStartDate()) || startDate.isEqual(reserve.getReserveEndDate())) {
+                if (isOverlapped(startDate, reserve)) {
                     return reserve.getReserveQty();
                 }
                 return 0;
@@ -155,10 +148,7 @@ public class ReserveValidator {
             .mapToObj(i -> startDate.plusDays(i)))
             .flatMap(localDateTime ->
                 reserveFlux.map(findReserve -> {
-                    if (localDateTime.isAfter(findReserve.getReserveStartDate())
-                        || localDateTime.isBefore(findReserve.getReserveEndDate())
-                        || localDateTime.isEqual(findReserve.getReserveStartDate()) || localDateTime.isEqual(findReserve.getReserveEndDate())
-                    ) {
+                    if (isOverlapped(localDateTime, findReserve)) {
                         return findReserve.getReserveQty();
                     }
                     return 0;
@@ -166,6 +156,18 @@ public class ReserveValidator {
             .groupBy(integer -> integer)
             .flatMap(group -> group.reduce((x1,x2) -> x1 > x2?x1:x2))
             .last(0);
+    }
+
+    /**
+     * 조회 날짜가 예약 기간(시작일~종료일, 양 끝 포함)에 겹치는지 판단한다.
+     *
+     * @param date 조회 날짜
+     * @param reserve 비교 대상 예약
+     * @return 겹치면 true
+     */
+    private boolean isOverlapped(LocalDateTime date, Reserve reserve) {
+        return !date.isBefore(reserve.getReserveStartDate())
+            && !date.isAfter(reserve.getReserveEndDate());
     }
 
     private String getMessage(String code) {

--- a/backend/reserve-request-service/src/test/java/org/egovframe/cloud/reserverequestservice/domain/ReserveValidatorTest.java
+++ b/backend/reserve-request-service/src/test/java/org/egovframe/cloud/reserverequestservice/domain/ReserveValidatorTest.java
@@ -1,0 +1,131 @@
+package org.egovframe.cloud.reserverequestservice.domain;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+
+import org.egovframe.cloud.common.exception.BusinessMessageException;
+import org.egovframe.cloud.common.util.MessageUtil;
+import org.egovframe.cloud.reserverequestservice.api.dto.ReserveSaveRequestDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+/**
+ * ReserveValidator 단위 테스트
+ *
+ * 장비 예약 재고 검증(checkEquipment)의 날짜 겹침 판정을 검증한다.
+ */
+@ExtendWith(MockitoExtension.class)
+class ReserveValidatorTest {
+
+    @Mock
+    private ReserveRepository reserveRepository;
+
+    @Mock
+    private MessageUtil messageUtil;
+
+    private ReserveValidator reserveValidator;
+
+    private static final LocalDateTime QUERY_DATE = LocalDateTime.of(2026, 6, 1, 10, 0);
+
+    @BeforeEach
+    void setUp() {
+        reserveValidator = new ReserveValidator(reserveRepository);
+        setField(reserveValidator, "messageUtil", messageUtil);
+        lenient().when(messageUtil.getMessage(anyString())).thenReturn("message");
+        lenient().when(messageUtil.getMessage(anyString(), any())).thenReturn("message");
+    }
+
+    /** 순수 리플렉션으로 비공개 필드를 주입한다(테스트 인프라 로깅 초기화 의존 회피). */
+    private static void setField(Object target, String name, Object value) {
+        try {
+            java.lang.reflect.Field field = target.getClass().getDeclaredField(name);
+            field.setAccessible(true);
+            field.set(target, value);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private ReserveSaveRequestDto equipmentDto(int totalQty, int reserveQty) {
+        // 조회 날짜를 단일 시점(reserveStartDate == reserveEndDate)으로 두어
+        // getMaxByReserveDate의 between == 0 분기를 태운다.
+        return ReserveSaveRequestDto.builder()
+            .categoryId("equipment")
+            .reserveItemId(1L)
+            .reserveMeansId("realtime")
+            .requestStartDate(LocalDateTime.of(2026, 1, 1, 0, 0))
+            .requestEndDate(LocalDateTime.of(2026, 12, 31, 0, 0))
+            .reserveStartDate(QUERY_DATE)
+            .reserveEndDate(QUERY_DATE)
+            .isPeriod(false)
+            .totalQty(totalQty)
+            .reserveQty(reserveQty)
+            .build();
+    }
+
+    private Reserve reserve(LocalDateTime start, LocalDateTime end, int qty) {
+        return Reserve.builder()
+            .reserveItemId(1L)
+            .reserveStartDate(start)
+            .reserveEndDate(end)
+            .reserveQty(qty)
+            .build();
+    }
+
+    @Test
+    void 조회날짜와_겹치지_않는_예약은_수량에_합산되지_않는다() {
+        // 예약 기간(5/1~5/2)이 조회 날짜(6/1)보다 모두 과거라 겹치지 않는다.
+        when(reserveRepository.findAllByReserveDate(anyLong(), any(), any()))
+            .thenReturn(Flux.just(reserve(
+                LocalDateTime.of(2026, 5, 1, 0, 0),
+                LocalDateTime.of(2026, 5, 2, 0, 0),
+                5)));
+
+        // max가 0이어야 totalQty(10) - 0 >= reserveQty(8)로 검증을 통과한다.
+        ReserveSaveRequestDto dto = equipmentDto(10, 8);
+
+        StepVerifier.create(reserveValidator.checkEquipment(dto))
+            .expectNext(dto)
+            .verifyComplete();
+    }
+
+    @Test
+    void 조회날짜와_겹치는_예약은_수량에_합산된다() {
+        // 예약 기간(5/30~6/2)이 조회 날짜(6/1)를 포함하여 겹친다.
+        when(reserveRepository.findAllByReserveDate(anyLong(), any(), any()))
+            .thenReturn(Flux.just(reserve(
+                LocalDateTime.of(2026, 5, 30, 0, 0),
+                LocalDateTime.of(2026, 6, 2, 0, 0),
+                5)));
+
+        // max가 5이므로 totalQty(10) - 5 = 5 < reserveQty(8)로 재고 부족 오류가 발생한다.
+        ReserveSaveRequestDto dto = equipmentDto(10, 8);
+
+        StepVerifier.create(reserveValidator.checkEquipment(dto))
+            .expectError(BusinessMessageException.class)
+            .verify();
+    }
+
+    @Test
+    void 예약이_없으면_재고_전체가_가용하다() {
+        when(reserveRepository.findAllByReserveDate(anyLong(), any(), any()))
+            .thenReturn(Flux.empty());
+
+        ReserveSaveRequestDto dto = equipmentDto(10, 8);
+
+        StepVerifier.create(reserveValidator.checkEquipment(dto))
+            .expectNext(dto)
+            .verifyComplete();
+    }
+}


### PR DESCRIPTION
## 변경 이유

`reserve-request-service`의 `ReserveValidator.getMaxByReserveDate`에서 예약 일자 겹침 판정이 잘못되어 있습니다.

```java
if (localDateTime.isAfter(s) || localDateTime.isBefore(e) || localDateTime.isEqual(s) || localDateTime.isEqual(e))
```

OR 결합이라 사실상 항상 참이 되어, 조회 기간과 겹치지 않는 예약까지 사용 수량에 합산됩니다. 그 결과 가용 재고가 실제보다 적게 계산되어, 예약 가능한 요청이 재고 부족으로 거부될 수 있습니다.

또한 `if (reserveFlux.equals(Flux.empty()))`는 항상 거짓이라 실행되지 않는 dead branch입니다.

## 변경 내용

기간 양 끝을 포함한 겹침 판정(`!date.isBefore(start) && !date.isAfter(end)`)으로 교정하고, 실행되지 않는 `Flux.empty()` 비교 dead branch를 제거합니다.

## 테스트 방법

`ReserveValidatorTest`(3건): 조회 날짜와 겹치지 않는 예약은 합산되지 않아 검증을 통과하고, 겹치는 예약은 합산되어 재고 부족 오류가 발생하며, 예약이 없으면 재고 전체가 가용함을 `StepVerifier`로 검증합니다.

## 영향 범위

`getMaxByReserveDate`의 겹침 판정만 변경합니다.
