### PR TITLE
[보안][msa-edu] config 하드코딩 DB/Eureka 자격증명 환경변수 외부화

### DIFF
--- a/backend/config/README.md
+++ b/backend/config/README.md
@@ -6,3 +6,16 @@
 
 ## 참고
 각 서비스에서 이 설정을 참조합니다.
+
+## 자격증명 환경 변수 오버라이드
+DB·Eureka 접속 자격증명은 설정 파일에 평문으로 두지 않고 환경 변수로 주입할 수 있습니다.
+값을 지정하지 않으면 기존 로컬 개발용 기본값(`msaportal`, `admin`)이 그대로 사용되므로 기존 구동 방식에는 영향이 없습니다.
+
+| 환경 변수 | 적용 대상 | 기본값 |
+|---|---|---|
+| `DB_USERNAME` | 각 서비스 datasource/r2dbc 사용자 | `msaportal` |
+| `DB_PASSWORD` | 각 서비스 datasource/r2dbc 비밀번호 | `msaportal` |
+| `EUREKA_USERNAME` | Eureka 클라이언트 접속 사용자 | `admin` |
+| `EUREKA_PASSWORD` | Eureka 클라이언트 접속 비밀번호 | `admin` |
+
+운영 환경에서는 컨테이너/배포 환경 변수로 위 값을 주입하여 평문 자격증명 노출을 피하는 것을 권장합니다.

--- a/backend/config/config/application.yml
+++ b/backend/config/config/application.yml
@@ -12,7 +12,7 @@ eureka:
     register-with-eureka: true # eureka 서버에 등록
     fetch-registry: true # 외부 검색 가능
     service-url:
-      defaultZone: http://admin:admin@${eureka.instance.hostname:localhost}:8761/eureka
+      defaultZone: http://${EUREKA_USERNAME:admin}:${EUREKA_PASSWORD:admin}@${eureka.instance.hostname:localhost}:8761/eureka
 
 # file attach location - messages{lang}.properties 도 이 경로에 위치한다.
 file:

--- a/backend/config/config/board-service.yml
+++ b/backend/config/config/board-service.yml
@@ -4,8 +4,8 @@ database:
 spring:
   datasource:
     url: ${database.url}?serverTimezone=Asia/Seoul&autoReconnect=true&validationQuery=select 1
-    username: msaportal
-    password: msaportal
+    username: ${DB_USERNAME:msaportal}
+    password: ${DB_PASSWORD:msaportal}
     driver-class-name: com.mysql.cj.jdbc.Driver
   cloud:
     stream:

--- a/backend/config/config/portal-service.yml
+++ b/backend/config/config/portal-service.yml
@@ -4,8 +4,8 @@ database:
 spring:
   datasource:
     url: ${database.url}?serverTimezone=Asia/Seoul&autoReconnect=true&validationQuery=select 1
-    username: msaportal
-    password: msaportal
+    username: ${DB_USERNAME:msaportal}
+    password: ${DB_PASSWORD:msaportal}
     driver-class-name: com.mysql.cj.jdbc.Driver
   cloud:
     bus:

--- a/backend/config/config/reserve-check-service.yml
+++ b/backend/config/config/reserve-check-service.yml
@@ -1,8 +1,8 @@
 spring:
   r2dbc:
     url: r2dbc:mysql://${mysql.hostname:localhost}:3306/reservation?serverTimezone=Asia/Seoul
-    username: msaportal
-    password: msaportal
+    username: ${DB_USERNAME:msaportal}
+    password: ${DB_PASSWORD:msaportal}
   cloud:
     stream:
       bindings:

--- a/backend/config/config/reserve-item-service.yml
+++ b/backend/config/config/reserve-item-service.yml
@@ -1,8 +1,8 @@
 spring:
   r2dbc:
     url: r2dbc:mysql://${mysql.hostname:localhost}:3306/msaportal?serverTimezone=Asia/Seoul
-    username: msaportal
-    password: msaportal
+    username: ${DB_USERNAME:msaportal}
+    password: ${DB_PASSWORD:msaportal}
   cloud:
     bus:
       destination: springCloudBus

--- a/backend/config/config/reserve-request-service.yml
+++ b/backend/config/config/reserve-request-service.yml
@@ -1,8 +1,8 @@
 spring:
   r2dbc:
     url: r2dbc:mysql://${mysql.hostname:localhost}:3306/reservation?serverTimezone=Asia/Seoul
-    username: msaportal
-    password: msaportal
+    username: ${DB_USERNAME:msaportal}
+    password: ${DB_PASSWORD:msaportal}
   cloud:
     bus:
       destination: springCloudBus

--- a/backend/config/config/user-service.yml
+++ b/backend/config/config/user-service.yml
@@ -4,8 +4,8 @@ database:
 spring:
   datasource:
     url: ${database.url}?serverTimezone=Asia/Seoul&autoReconnect=true&validationQuery=select 1
-    username: msaportal
-    password: msaportal
+    username: ${DB_USERNAME:msaportal}
+    password: ${DB_PASSWORD:msaportal}
     driver-class-name: com.mysql.cj.jdbc.Driver
   mail: # 비밀번호 변경 이메일 발송
     host: smtp.gmail.com # smtp host

--- a/config/application.yml
+++ b/config/application.yml
@@ -12,7 +12,7 @@ eureka:
     register-with-eureka: true # eureka 서버에 등록
     fetch-registry: true # 외부 검색 가능
     service-url:
-      defaultZone: http://admin:admin@${eureka.instance.hostname:localhost}:8761/eureka
+      defaultZone: http://${EUREKA_USERNAME:admin}:${EUREKA_PASSWORD:admin}@${eureka.instance.hostname:localhost}:8761/eureka
 
 # file attach location - messages{lang}.properties 도 이 경로에 위치한다.
 file:

--- a/config/board-service.yml
+++ b/config/board-service.yml
@@ -4,8 +4,8 @@ database:
 spring:
   datasource:
     url: ${database.url}?serverTimezone=Asia/Seoul&autoReconnect=true&validationQuery=select 1
-    username: msaportal
-    password: msaportal
+    username: ${DB_USERNAME:msaportal}
+    password: ${DB_PASSWORD:msaportal}
     driver-class-name: com.mysql.cj.jdbc.Driver
   cloud:
     stream:

--- a/config/portal-service.yml
+++ b/config/portal-service.yml
@@ -4,8 +4,8 @@ database:
 spring:
   datasource:
     url: ${database.url}?serverTimezone=Asia/Seoul&autoReconnect=true&validationQuery=select 1
-    username: msaportal
-    password: msaportal
+    username: ${DB_USERNAME:msaportal}
+    password: ${DB_PASSWORD:msaportal}
     driver-class-name: com.mysql.cj.jdbc.Driver
   cloud:
     bus:

--- a/config/reserve-check-service.yml
+++ b/config/reserve-check-service.yml
@@ -1,8 +1,8 @@
 spring:
   r2dbc:
     url: r2dbc:mysql://${mysql.hostname:localhost}:3306/reservation?serverTimezone=Asia/Seoul
-    username: msaportal
-    password: msaportal
+    username: ${DB_USERNAME:msaportal}
+    password: ${DB_PASSWORD:msaportal}
   cloud:
     stream:
       bindings:

--- a/config/reserve-item-service.yml
+++ b/config/reserve-item-service.yml
@@ -1,8 +1,8 @@
 spring:
   r2dbc:
     url: r2dbc:mysql://${mysql.hostname:localhost}:3306/msaportal?serverTimezone=Asia/Seoul
-    username: msaportal
-    password: msaportal
+    username: ${DB_USERNAME:msaportal}
+    password: ${DB_PASSWORD:msaportal}
   cloud:
     bus:
       destination: springCloudBus

--- a/config/reserve-request-service.yml
+++ b/config/reserve-request-service.yml
@@ -1,8 +1,8 @@
 spring:
   r2dbc:
     url: r2dbc:mysql://${mysql.hostname:localhost}:3306/reservation?serverTimezone=Asia/Seoul
-    username: msaportal
-    password: msaportal
+    username: ${DB_USERNAME:msaportal}
+    password: ${DB_PASSWORD:msaportal}
   cloud:
     bus:
       destination: springCloudBus

--- a/config/user-service.yml
+++ b/config/user-service.yml
@@ -4,8 +4,8 @@ database:
 spring:
   datasource:
     url: ${database.url}?serverTimezone=Asia/Seoul&autoReconnect=true&validationQuery=select 1
-    username: msaportal
-    password: msaportal
+    username: ${DB_USERNAME:msaportal}
+    password: ${DB_PASSWORD:msaportal}
     driver-class-name: com.mysql.cj.jdbc.Driver
   mail: # 비밀번호 변경 이메일 발송
     host: smtp.gmail.com # smtp host


### PR DESCRIPTION
## 변경 사유
각 서비스 설정 파일에 DB 접속 정보(`username/password: msaportal`)와 Eureka 클라이언트 접속 정보(`admin:admin`)가 평문으로 하드코딩되어 있습니다(CWE-798: Use of Hard-coded Credentials). 운영 환경에서 평문 자격증명이 그대로 노출되지 않도록 환경 변수로 주입 가능하게 외부화합니다.

## 변경 내용
- **DB 자격증명** (6개 서비스: board·portal·user·reserve-item·reserve-check·reserve-request)
  - `username: msaportal` → `username: ${DB_USERNAME:msaportal}`
  - `password: msaportal` → `password: ${DB_PASSWORD:msaportal}`
  - JPA(datasource)·R2DBC 양쪽 모두 적용
- **Eureka 자격증명** (`application.yml`)
  - `http://admin:admin@...` → `http://${EUREKA_USERNAME:admin}:${EUREKA_PASSWORD:admin}@...`
- `config/` 와 `backend/config/config/` 두 디렉토리가 동일 설정을 공유하므로(루트 `config/`는 docker-compose 볼륨 마운트, `backend/config/config/`는 로컬 config-service의 `file:./config` 검색 경로) **양쪽 모두 동일하게 반영**했습니다.
- `backend/config/README.md`에 오버라이드 가능한 환경 변수 표를 추가했습니다.

## 기존 동작 영향
- 모든 외부화에 **기존 기본값을 그대로 유지**(`:msaportal`, `:admin`)하여, 환경 변수를 지정하지 않으면 종전과 동일하게 동작합니다. 로컬 개발·`docker-compose` 구동에 영향 없습니다.

## 환경 변수
| 변수 | 대상 | 기본값 |
|---|---|---|
| `DB_USERNAME` / `DB_PASSWORD` | 각 서비스 DB 접속 | `msaportal` |
| `EUREKA_USERNAME` / `EUREKA_PASSWORD` | Eureka 클라이언트 접속 | `admin` |

## 검증
- 변경한 15개 YAML 전부 파싱 정상 확인.
- 평문 `msaportal` / `admin:admin@` 잔존 없음 확인.
- 실 클러스터 E2E 기동은 환경상 검증하지 못했고, 기본값 보존으로 기존 동작이 유지되는 점까지 정적으로 확인했습니다.

## 체크리스트
- [x] 단일 주제만 다룸(자격증명 외부화)
- [x] 기존 동작 영향 없음(기본값 보존)
- [x] 두 config 디렉토리 일관 반영