### PR TITLE
fix: 이메일 검증이 6자 초과 최상위 도메인을 거부하는 문제 수정

### DIFF
--- a/frontend/portal/src/components/UserInfo/UserInfoModified.tsx
+++ b/frontend/portal/src/components/UserInfo/UserInfoModified.tsx
@@ -3,7 +3,7 @@ import { BottomButtons, IButtons } from '@components/Buttons'
 import { DLWrapper } from '@components/WriteDLFields'
 import { userService } from '@service'
 import { errorStateSelector, userAtom } from '@stores'
-import { format } from '@utils'
+import { EMAIL_PATTERN, format, isValidEmail } from '@utils'
 import React, { useMemo } from 'react'
 import { Controller, UseFormGetValues, UseFormSetFocus } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
@@ -43,11 +43,7 @@ const UserInfoModified = (props: UserInfoModifiedPrpps) => {
       return
     }
 
-    if (
-      /^([\w-]+(?:\.[\w-]+)*)@((?:[\w-]+\.)*\w[\w-]{0,66})\.([a-z]{2,6}(?:\.[a-z]{2})?)$/i.test(
-        emailValue,
-      ) === false
-    ) {
+    if (isValidEmail(emailValue) === false) {
       showMessage(t('valid.email.pattern'), () => setFocus('email'))
       return
     }
@@ -121,8 +117,7 @@ const UserInfoModified = (props: UserInfoModifiedPrpps) => {
               message: format(t('valid.maxlength.format'), [50]),
             },
             pattern: {
-              value:
-                /^([\w-]+(?:\.[\w-]+)*)@((?:[\w-]+\.)*\w[\w-]{0,66})\.([a-z]{2,6}(?:\.[a-z]{2})?)$/i,
+              value: EMAIL_PATTERN,
               message: t('valid.email.pattern'),
             },
           }}

--- a/frontend/portal/src/pages/auth/find/password/index.tsx
+++ b/frontend/portal/src/pages/auth/find/password/index.tsx
@@ -3,7 +3,7 @@ import CircularProgress from '@material-ui/core/CircularProgress'
 import { makeStyles, Theme } from '@material-ui/core/styles'
 import Alert from '@material-ui/lab/Alert'
 import { userService } from '@service'
-import { format } from '@utils'
+import { EMAIL_PATTERN, format } from '@utils'
 import { useRouter } from 'next/router'
 import React, { useState } from 'react'
 import { Controller, useForm } from 'react-hook-form'
@@ -152,8 +152,7 @@ const FindPassword = () => {
                     message: format(t('valid.maxlength.format'), [50]),
                   },
                   pattern: {
-                    value:
-                      /^([\w-]+(?:\.[\w-]+)*)@((?:[\w-]+\.)*\w[\w-]{0,66})\.([a-z]{2,6}(?:\.[a-z]{2})?)$/i,
+                    value: EMAIL_PATTERN,
                     message: t('valid.email.pattern'),
                   },
                 }}

--- a/frontend/portal/src/pages/auth/join/form.tsx
+++ b/frontend/portal/src/pages/auth/join/form.tsx
@@ -3,7 +3,7 @@ import { DLWrapper } from '@components/WriteDLFields'
 import { makeStyles, Theme } from '@material-ui/core/styles'
 import Alert from '@material-ui/lab/Alert'
 import { ISocialUser, userService } from '@service'
-import { format, isValidPassword } from '@utils'
+import { EMAIL_PATTERN, format, isValidEmail, isValidPassword } from '@utils'
 import { GetServerSideProps } from 'next'
 import { useRouter } from 'next/router'
 import React, { createRef, useEffect, useState } from 'react'
@@ -92,11 +92,7 @@ const Form = (props: FormProps) => {
     const emailElement = emailRef.current
     const email = emailElement?.value
 
-    if (
-      /^([\w-]+(?:\.[\w-]+)*)@((?:[\w-]+\.)*\w[\w-]{0,66})\.([a-z]{2,6}(?:\.[a-z]{2})?)$/i.test(
-        email,
-      ) === false
-    ) {
+    if (isValidEmail(email) === false) {
       showMessage(t('valid.email.pattern'), () => {
         emailElement?.focus()
       })
@@ -199,8 +195,7 @@ const Form = (props: FormProps) => {
                     message: format(t('valid.maxlength.format'), [50]),
                   },
                   pattern: {
-                    value:
-                      /^([\w-]+(?:\.[\w-]+)*)@((?:[\w-]+\.)*\w[\w-]{0,66})\.([a-z]{2,6}(?:\.[a-z]{2})?)$/i,
+                    value: EMAIL_PATTERN,
                     message: t('valid.email.pattern'),
                   },
                 }}

--- a/frontend/portal/src/utils/__tests__/isValidEmail.test.ts
+++ b/frontend/portal/src/utils/__tests__/isValidEmail.test.ts
@@ -1,0 +1,41 @@
+import { isValidEmail } from '@utils'
+
+describe('isValidEmail', () => {
+  describe('정상 이메일은 통과한다', () => {
+    const validEmails = [
+      'user@example.com',
+      'user@example.io',
+      'user.name@example.co.kr',
+      'user-name@sub.example.com',
+      // 6자를 초과하는 신규 일반 최상위 도메인(gTLD)
+      'user@example.technology',
+      'user@example.engineering',
+      'user@example.international',
+    ]
+
+    validEmails.forEach(email => {
+      it(`${email}`, () => {
+        expect(isValidEmail(email)).toBe(true)
+      })
+    })
+  })
+
+  describe('비정상 이메일은 거부한다', () => {
+    const invalidEmails = [
+      '',
+      'user',
+      'user@',
+      'user@example',
+      '@example.com',
+      // 최상위 도메인이 1자
+      'a@b.c',
+      'user example.com',
+    ]
+
+    invalidEmails.forEach(email => {
+      it(`${email || '(빈 문자열)'}`, () => {
+        expect(isValidEmail(email)).toBe(false)
+      })
+    })
+  })
+})

--- a/frontend/portal/src/utils/index.ts
+++ b/frontend/portal/src/utils/index.ts
@@ -71,3 +71,12 @@ export const nl2Br = html => {
 export const isValidPassword = value => {
   return /^(?=.*?[a-zA-Z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-]).{8,20}$/.test(value)
 }
+
+// 이메일 형식 정규식 (최상위 도메인 길이는 DNS 라벨 최대치인 63자까지 허용)
+export const EMAIL_PATTERN =
+  /^([\w-]+(?:\.[\w-]+)*)@((?:[\w-]+\.)*\w[\w-]{0,66})\.([a-z]{2,63}(?:\.[a-z]{2})?)$/i
+
+// 이메일 형식 확인
+export const isValidEmail = value => {
+  return EMAIL_PATTERN.test(value)
+}


### PR DESCRIPTION
## 변경 이유

이메일 형식 검증 정규식의 최상위 도메인 부분이 `[a-z]{2,6}`으로 제한되어 있습니다.

```
/^([\w-]+(?:\.[\w-]+)*)@((?:[\w-]+\.)*\w[\w-]{0,66})\.([a-z]{2,6}(?:\.[a-z]{2})?)$/i
```

이 때문에 `.technology`·`.engineering`·`.international`처럼 6자를 넘는 신규 일반 최상위 도메인(gTLD)을 쓰는 정상 이메일이 거부됩니다. 같은 정규식이 세 화면에 중복되어 있어, 회원가입·회원정보수정·비밀번호 찾기 모두에서 같은 문제가 발생합니다.

- `frontend/portal/src/components/UserInfo/UserInfoModified.tsx`
- `frontend/portal/src/pages/auth/join/form.tsx`
- `frontend/portal/src/pages/auth/find/password/index.tsx`

## 변경 내용

- 최상위 도메인 길이 제한을 DNS 라벨 최대치인 63자로 넓혔습니다(`{2,6}` → `{2,63}`). `.co.kr` 같은 2단계 도메인 허용은 그대로 둡니다.
- 같은 정규식이 세 곳에 중복되어 있어, 공통 유틸 `EMAIL_PATTERN`·`isValidEmail`(`src/utils/index.ts`)로 추출하고 세 화면이 이를 함께 쓰도록 정리했습니다.

## 테스트 방법

`src/utils/__tests__/isValidEmail.test.ts`(jest 14건):
- 통과: `.com`·`.io`·`.co.kr`·서브도메인·`.technology`·`.engineering`·`.international`
- 거부: 빈 문자열·`@` 누락·최상위 도메인 누락·1자 최상위 도메인·공백 포함

변경 전에는 `.technology` 등이 거부되어 이 테스트가 실패하고, 변경 후 통과합니다.

## 영향 범위

이메일 형식 검증만 바뀌며, 기존에 통과하던 정상 이메일의 동작은 동일합니다.
