### PR TITLE
[보안][msa-edu] frontend axios 0.21.1 → 0.28.1 (CVE-2023-45857)

### DIFF
--- a/frontend/admin/package.json
+++ b/frontend/admin/package.json
@@ -43,7 +43,7 @@
     "@material-ui/styles": "^4.11.4",
     "@next/bundle-analyzer": "^11.1.0",
     "@types/form-data": "^2.5.0",
-    "axios": "^0.21.1",
+    "axios": "^0.28.1",
     "classnames": "^2.3.1",
     "cookies": "^0.8.0",
     "date-fns": "^2.23.0",

--- a/frontend/portal/package.json
+++ b/frontend/portal/package.json
@@ -32,7 +32,7 @@
     "@material-ui/data-grid": "^4.0.0-alpha.37",
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "4.0.0-alpha.60",
-    "axios": "^0.21.1",
+    "axios": "^0.28.1",
     "cookies": "^0.8.0",
     "cors": "^2.8.5",
     "date-fns": "^2.23.0",


### PR DESCRIPTION
## 변경 사유
프론트엔드 `axios`가 `^0.21.1`로 고정되어 있어 **CVE-2023-45857**에 노출됩니다.

- 영향: `withCredentials` 사용 시 `XSRF-TOKEN` 쿠키 값이 동일 출처가 아닌(cross-origin) 요청의 `X-XSRF-TOKEN` 헤더에도 자동 첨부되어, 리다이렉트 등으로 제3자 호스트에 토큰이 유출될 수 있습니다.
- 적용 영향 범위: axios 0.8.1 ~ 1.5.x. 본 프로젝트의 `0.21.1`이 해당됩니다.
- portal·admin 모두 `_app/index.tsx`에서 `axios.defaults.withCredentials = true`를 설정합니다.

## 변경 내용
- `frontend/portal/package.json`: `axios ^0.21.1 → ^0.28.1`
- `frontend/admin/package.json`: `axios ^0.21.1 → ^0.28.1`

`0.28.1`은 axios **0.x 라인의 종착 보안 패치**로, XSRF 토큰을 동일 출처로 제한하는 수정(`withXSRFToken`)이 백포트되어 있습니다. 1.x로의 메이저 업그레이드 없이 취약점만 해소합니다.

빌드가 `npm install` 기반(`frontend/*/Dockerfile`)이라 lockfile 변경 없이 `package.json` 버전 상향만으로 반영됩니다. (admin은 lockfileVersion 1이라 `npm`으로 lock을 재생성하면 포맷 전면 재작성이 발생하여, 노이즈를 피하고자 의도적으로 `package.json`만 변경했습니다.)

## 영향 / 호환성
- 호출부는 `axios.defaults.baseURL` · `axios.defaults.headers.common[...]`(JWT 헤더 인증) · `withCredentials`만 사용하며, `axios.create`/인터셉터/`paramsSerializer`/XSRF 자동 헤더에 의존하지 않습니다. 0.22~0.28의 동작 변경(XSRF 동일 출처 제한 = 본 보안 수정)이 기존 동작에 영향을 주지 않습니다.

## 테스트 / 미검증 (정직 표기)
- npm 레지스트리에서 `axios@0.28.1` 실재 및 CVE-2023-45857 수정 포함은 확인했습니다.
- 다만 **프론트엔드 빌드/기동/브라우저 E2E는 수행하지 못했습니다**(로컬 제약). 호출부 정적 검토 기준으로 비호환 API 사용은 없습니다.

## 체크리스트
- [x] 단일 주제(axios 보안 패치)만 다룸
- [x] base = main
- [x] 기존 동작 영향 없음(호출부 정적 검토)
- [ ] 빌드/E2E 미검증(위 명시)