### PR TITLE
fix: user-service loadUserByUsername 소셜 회원 판별 연산자 우선순위 버그 수정

### DIFF
--- a/backend/user-service/build.gradle
+++ b/backend/user-service/build.gradle
@@ -106,6 +106,9 @@ dependencyManagement {
 
 test {
     useJUnitPlatform()
+    // 테스트 클래스패스에 log4j-slf4j2-impl 과 log4j-to-slf4j 가 함께 존재하여 발생하는 바인딩 충돌을 방지한다.
+    // 운영과 동일하게 logback 을 slf4j 프로바이더로 고정한다.
+    systemProperty 'slf4j.provider', 'ch.qos.logback.classic.spi.LogbackServiceProvider'
 }
 
 // querydsl 추가 시작

--- a/backend/user-service/src/main/java/org/egovframe/cloud/userservice/service/user/UserService.java
+++ b/backend/user-service/src/main/java/org/egovframe/cloud/userservice/service/user/UserService.java
@@ -271,7 +271,7 @@ public class UserService extends AbstractService implements UserDetailsService {
         ArrayList<GrantedAuthority> authorities = new ArrayList<>();
         authorities.add(new SimpleGrantedAuthority(user.getRoleKey()));
 
-        if (user.isSocialUser() && user.getEncryptedPassword() == null || "".equals(user.getEncryptedPassword())) { // 소셜 회원이고 비밀번호가 등록되지 않은 경우
+        if (user.isSocialUser() && (user.getEncryptedPassword() == null || "".equals(user.getEncryptedPassword()))) { // 소셜 회원이고 비밀번호가 등록되지 않은 경우
             return new SocialUser(user.getEmail(), authorities);
         } else {
             return new org.springframework.security.core.userdetails.User(user.getEmail(), user.getEncryptedPassword(), authorities);

--- a/backend/user-service/src/test/java/org/egovframe/cloud/userservice/service/user/UserServiceTest.java
+++ b/backend/user-service/src/test/java/org/egovframe/cloud/userservice/service/user/UserServiceTest.java
@@ -1,0 +1,132 @@
+package org.egovframe.cloud.userservice.service.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.egovframe.cloud.common.domain.Role;
+import org.egovframe.cloud.userservice.config.dto.SocialUser;
+import org.egovframe.cloud.userservice.domain.user.User;
+import org.egovframe.cloud.userservice.domain.user.UserRepository;
+import org.egovframe.cloud.userservice.domain.user.UserStateCode;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+/**
+ * org.egovframe.cloud.userservice.service.user.UserServiceTest
+ * <p>
+ * UserService.loadUserByUsername 의 소셜 회원 판별 분기 단위 테스트
+ *
+ * @author 표준프레임워크센터
+ * @version 1.0
+ */
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private UserService userService;
+
+    @BeforeEach
+    void setUp() {
+        // loadUserByUsername 내부에서 RequestContextHolder 를 사용하므로 요청 컨텍스트를 세팅한다.
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(new MockHttpServletRequest()));
+    }
+
+    @AfterEach
+    void tearDown() {
+        RequestContextHolder.resetRequestAttributes();
+    }
+
+    /**
+     * 테스트용 사용자 엔티티 생성
+     */
+    private User user(String email, String encryptedPassword, String socialProvider, String socialId) {
+        User.UserBuilder builder = User.builder()
+                .userId("uid-" + email)
+                .userName("tester")
+                .email(email)
+                .encryptedPassword(encryptedPassword)
+                .role(Role.USER)
+                .userStateCode(UserStateCode.NORMAL.getKey());
+        if ("google".equals(socialProvider)) builder.googleId(socialId);
+        else if ("kakao".equals(socialProvider)) builder.kakaoId(socialId);
+        else if ("naver".equals(socialProvider)) builder.naverId(socialId);
+        return builder.build();
+    }
+
+    @Test
+    @DisplayName("비-소셜 회원이고 비밀번호가 빈 문자열이면 일반 User 로 반환된다")
+    void loadUserByUsername_nonSocialEmptyPassword_returnsGeneralUser() {
+        // given
+        String email = "nonsocial@egovframe.org";
+        when(userRepository.findByEmail(email)).thenReturn(Optional.of(user(email, "", null, null)));
+
+        // when
+        UserDetails userDetails = userService.loadUserByUsername(email);
+
+        // then : 연산자 우선순위 버그가 있으면 SocialUser 로 새어나간다. 일반 User 여야 한다.
+        assertThat(userDetails).isNotInstanceOf(SocialUser.class);
+        assertThat(userDetails).isInstanceOf(org.springframework.security.core.userdetails.User.class);
+        assertThat(userDetails.getUsername()).isEqualTo(email);
+    }
+
+    @Test
+    @DisplayName("소셜 회원이고 비밀번호가 null 이면 SocialUser 로 반환된다")
+    void loadUserByUsername_socialNullPassword_returnsSocialUser() {
+        // given
+        String email = "social-null@egovframe.org";
+        when(userRepository.findByEmail(email)).thenReturn(Optional.of(user(email, null, "google", "g-123")));
+
+        // when
+        UserDetails userDetails = userService.loadUserByUsername(email);
+
+        // then
+        assertThat(userDetails).isInstanceOf(SocialUser.class);
+        assertThat(userDetails.getUsername()).isEqualTo(email);
+    }
+
+    @Test
+    @DisplayName("소셜 회원이고 비밀번호가 빈 문자열이면 SocialUser 로 반환된다")
+    void loadUserByUsername_socialEmptyPassword_returnsSocialUser() {
+        // given
+        String email = "social-empty@egovframe.org";
+        when(userRepository.findByEmail(email)).thenReturn(Optional.of(user(email, "", "naver", "n-123")));
+
+        // when
+        UserDetails userDetails = userService.loadUserByUsername(email);
+
+        // then
+        assertThat(userDetails).isInstanceOf(SocialUser.class);
+    }
+
+    @Test
+    @DisplayName("일반 회원이고 정상 비밀번호가 있으면 일반 User 로 반환된다")
+    void loadUserByUsername_generalUserWithPassword_returnsGeneralUser() {
+        // given
+        String email = "general@egovframe.org";
+        String encryptedPassword = "$2a$10$encryptedpasswordsample";
+        when(userRepository.findByEmail(email)).thenReturn(Optional.of(user(email, encryptedPassword, null, null)));
+
+        // when
+        UserDetails userDetails = userService.loadUserByUsername(email);
+
+        // then
+        assertThat(userDetails).isNotInstanceOf(SocialUser.class);
+        assertThat(userDetails).isInstanceOf(org.springframework.security.core.userdetails.User.class);
+        assertThat(userDetails.getPassword()).isEqualTo(encryptedPassword);
+    }
+}


### PR DESCRIPTION
## 변경 이유

`UserService.loadUserByUsername` 의 소셜 회원 판별 조건에 연산자 우선순위 버그가 있습니다.

```java
if (user.isSocialUser() && user.getEncryptedPassword() == null || "".equals(user.getEncryptedPassword())) {
```

`&&` 는 `||` 보다 먼저 결합하므로 이 조건은 다음과 같이 평가됩니다.

```
(isSocialUser() && encryptedPassword == null) || "".equals(encryptedPassword)
```

따라서 소셜 회원이 아니더라도 `encryptedPassword` 가 빈 문자열이면 `SocialUser`(비밀번호 null) 분기로 반환됩니다. 이 경우 일반 비밀번호 인증 경로를 우회하게 되어, 주석이 명시한 의도("소셜 회원이고 비밀번호가 등록되지 않은 경우")와 동작이 어긋납니다.

## 변경 내용

주석 의도대로 괄호를 추가해 조건을 복원합니다.

```java
if (user.isSocialUser() && (user.getEncryptedPassword() == null || "".equals(user.getEncryptedPassword()))) {
```

- 소셜 회원의 동작은 그대로 유지됩니다.
- 비-소셜 회원이면서 `encryptedPassword` 가 빈 문자열인 경우만 일반 인증 분기로 바로잡습니다.

`loadUserByUsername` 단위 테스트 4건을 추가했습니다. 수정 전 조건으로 되돌리면 실패하도록 작성하여 회귀를 방어합니다.

`test` 태스크에 한해 SLF4J 프로바이더를 logback 으로 고정했습니다. 테스트 클래스패스에 `log4j-slf4j2-impl` 과 `log4j-to-slf4j` 가 함께 존재해 발생하는 프로바이더 바인딩 충돌을 해소하기 위함이며, 운영 동작에는 영향이 없습니다.

## 테스트 방법

```bash
cd backend/user-service
./gradlew test --tests '*UserServiceTest'
```

- 비-소셜 회원 + 빈 비밀번호: 일반 `User`(비밀번호 보존) 반환을 확인합니다.
- 소셜 회원 + 비밀번호 미등록: `SocialUser` 반환을 확인합니다.
- 소셜 회원 + 비밀번호 보유, 일반 회원 + 비밀번호 보유 분기를 함께 검증합니다.

## 영향 범위

- 변경 파일: `backend/user-service/.../service/user/UserService.java`(조건 1줄), 동일 경로 테스트 추가, `backend/user-service/build.gradle`(test 태스크 한정).
- 인증 분기 동작 교정으로, 비-소셜 회원의 비밀번호 인증이 정상 경로를 타도록 합니다. 소셜 로그인 동작은 불변입니다.
