### PR TITLE
[보안][msa-edu] Spring Boot 3.5.6 → 3.5.16, Spring Cloud 2025.0.0 → 2025.0.3 (3.5 EOL 전 패치 반영)

### DIFF
--- a/backend/apigateway/build.gradle
+++ b/backend/apigateway/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '3.5.6'
+    id 'org.springframework.boot' version '3.5.16'
     id 'org.sonarqube' version '3.5.0.2730'
     id 'io.spring.dependency-management' version '1.1.0'
     id 'java'
@@ -17,7 +17,7 @@ repositories {
 
 ext {
     set('egovframeBootParentVersion', '5.0.0')
-    set('springCloudVersion', '2025.0.0')
+    set('springCloudVersion', '2025.0.3')
 }
 
 dependencies {

--- a/backend/board-service/build.gradle
+++ b/backend/board-service/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '3.5.6'
+    id 'org.springframework.boot' version '3.5.16'
     id 'org.sonarqube' version '3.5.0.2730'
     id 'io.spring.dependency-management' version '1.1.0'
     id 'java'
@@ -23,7 +23,7 @@ repositories {
 
 ext {
     set('egovframeBootParentVersion', '5.0.0')
-    set('springCloudVersion', '2025.0.0')
+    set('springCloudVersion', '2025.0.3')
 }
 
 dependencies {

--- a/backend/config/build.gradle
+++ b/backend/config/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '3.5.6'
+    id 'org.springframework.boot' version '3.5.16'
     id 'io.spring.dependency-management' version '1.1.0'
     id 'java'
 }
@@ -16,7 +16,7 @@ repositories {
 
 ext {
     set('egovframeBootParentVersion', '5.0.0')
-    set('springCloudVersion', '2025.0.0')
+    set('springCloudVersion', '2025.0.3')
 }
 
 dependencies {

--- a/backend/discovery/build.gradle
+++ b/backend/discovery/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '3.5.6'
+    id 'org.springframework.boot' version '3.5.16'
     id 'io.spring.dependency-management' version '1.1.0'
     id 'java'
 }
@@ -16,7 +16,7 @@ repositories {
 
 ext {
     set('egovframeBootParentVersion', '5.0.0')
-    set('springCloudVersion', '2025.0.0')
+    set('springCloudVersion', '2025.0.3')
 }
 
 dependencies {

--- a/backend/portal-service/build.gradle
+++ b/backend/portal-service/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '3.5.6'
+    id 'org.springframework.boot' version '3.5.16'
     id 'org.sonarqube' version '3.5.0.2730'
     id 'io.spring.dependency-management' version '1.1.0'
     id 'java'
@@ -23,7 +23,7 @@ repositories {
 
 ext {
     set('egovframeBootParentVersion', '5.0.0')
-    set('springCloudVersion', '2025.0.0')
+    set('springCloudVersion', '2025.0.3')
 }
 
 dependencies {

--- a/backend/reserve-check-service/build.gradle
+++ b/backend/reserve-check-service/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '3.5.6'
+    id 'org.springframework.boot' version '3.5.16'
     id 'io.spring.dependency-management' version '1.1.0'
     id 'java'
 }
@@ -23,7 +23,7 @@ repositories {
 
 ext {
     set('egovframeBootParentVersion', '5.0.0')
-    set('springCloudVersion', '2025.0.0')
+    set('springCloudVersion', '2025.0.3')
 }
 
 dependencies {

--- a/backend/reserve-item-service/build.gradle
+++ b/backend/reserve-item-service/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '3.5.6'
+    id 'org.springframework.boot' version '3.5.16'
     id 'io.spring.dependency-management' version '1.1.0'
     id 'java'
 }
@@ -22,7 +22,7 @@ repositories {
 
 ext {
     set('egovframeBootParentVersion', '5.0.0')
-    set('springCloudVersion', '2025.0.0')
+    set('springCloudVersion', '2025.0.3')
 }
 
 dependencies {

--- a/backend/reserve-request-service/build.gradle
+++ b/backend/reserve-request-service/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '3.5.6'
+    id 'org.springframework.boot' version '3.5.16'
     id 'io.spring.dependency-management' version '1.1.0'
     id 'java'
 }
@@ -22,7 +22,7 @@ repositories {
 
 ext {
     set('egovframeBootParentVersion', '5.0.0')
-    set('springCloudVersion', '2025.0.0')
+    set('springCloudVersion', '2025.0.3')
 }
 
 dependencies {

--- a/backend/user-service/build.gradle
+++ b/backend/user-service/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '3.5.6'
+    id 'org.springframework.boot' version '3.5.16'
     id 'org.sonarqube' version '3.5.0.2730'
     id 'io.spring.dependency-management' version '1.1.0'
     id 'java'
@@ -24,7 +24,7 @@ repositories {
 
 ext {
     set('egovframeBootParentVersion', '5.0.0')
-    set('springCloudVersion', '2025.0.0')
+    set('springCloudVersion', '2025.0.3')
 }
 
 dependencies {


### PR DESCRIPTION
## 변경 사유

Spring Boot **3.5 OSS 지원이 2026-06-30 종료**됩니다. 종료 전, 3.5.x 라인의 마지막 누적 보안·안정화 패치인 **3.5.16**을 반영합니다. 함께 사용하는 Spring Cloud 릴리스 트레인도 동일 트레인 패치(**2025.0.3**)로 맞춥니다.

## 변경 내용

백엔드 9개 서비스의 `build.gradle`:

- `org.springframework.boot` 플러그인: `3.5.6` → `3.5.16`
- `springCloudVersion`: `2025.0.0` → `2025.0.3`

대상: apigateway, board-service, config, discovery, portal-service, reserve-check-service, reserve-item-service, reserve-request-service, user-service (각 2줄, 총 9파일).

모두 **동일 마이너/트레인 내 패치 업데이트**로 API 호환되며, 추가 코드 변경은 없습니다.

## 검증

- 대상 버전 모두 Maven Central에 존재함을 확인(spring-boot 3.5.16, spring-cloud-dependencies 2025.0.3).
- 대표·고위험 모듈 2개를 JDK 17로 컴파일 검증:
  - `board-service`(JPA + Cloud config/eureka/bus/stream): `./gradlew compileJava` → **BUILD SUCCESSFUL**
  - `apigateway`(Spring Cloud Gateway + WebFlux): `./gradlew compileJava` → **BUILD SUCCESSFUL**
- 전체 기동/통합 테스트는 로컬에서 수행하지 못했습니다(서비스 다수 기동 필요). 패치 레벨 업데이트라 동작 변경은 없으나, 병합 전 기동 검증은 메인테이너 환경 기준으로 부탁드립니다.

## 체크리스트
- [x] 단일 주제(프레임워크 버전 패치)만 변경
- [x] base = main
- [x] 동일 트레인 내 패치라 기존 동작 영향 없음(컴파일 검증)
- [x] 추가 의존성/코드 변경 없음