### PR TITLE
fix: 예약 물품 재고 이중차감으로 인한 재고 손상 수정

### DIFF
--- a/backend/reserve-item-service/build.gradle
+++ b/backend/reserve-item-service/build.gradle
@@ -28,6 +28,7 @@ ext {
 dependencies {
 //    implementation files('../module-common/build/libs/egovframe-cloud-module-common.jar') // @ComponentScan(basePackages={"org.egovframe.cloud"}) 추가해야 적용된다
     implementation("org.egovframe.cloud:egovframe-cloud-module-common:${egovframeBootParentVersion}") {
+        exclude group: 'org.egovframe.rte', module: 'egovframe-rte-fdl-logging'
         exclude group: 'commons-logging', module: 'commons-logging'
     }
     implementation("org.egovframe.rte:egovframe-rte-fdl-cmmn:${egovframeBootParentVersion}") {

--- a/backend/reserve-item-service/src/main/java/org/egovframe/cloud/reserveitemservice/service/reserveItem/ReserveItemService.java
+++ b/backend/reserve-item-service/src/main/java/org/egovframe/cloud/reserveitemservice/service/reserveItem/ReserveItemService.java
@@ -166,7 +166,7 @@ public class ReserveItemService extends ReactiveAbstractService {
                     if (qty < 0) {
                         return Mono.just(false);
                     }
-                    return reserveItemRepository.save(reserveItem.updateInventoryQty(qty)).thenReturn(true);
+                    return reserveItemRepository.save(reserveItem.updateInventoryQty(reserveQty)).thenReturn(true);
                 });
     }
 

--- a/backend/reserve-item-service/src/test/java/org/egovframe/cloud/reserveitemservice/service/reserveItem/ReserveItemServiceTest.java
+++ b/backend/reserve-item-service/src/test/java/org/egovframe/cloud/reserveitemservice/service/reserveItem/ReserveItemServiceTest.java
@@ -1,0 +1,98 @@
+package org.egovframe.cloud.reserveitemservice.service.reserveItem;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.egovframe.cloud.reserveitemservice.domain.reserveItem.ReserveItem;
+import org.egovframe.cloud.reserveitemservice.domain.reserveItem.ReserveItemRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cloud.stream.function.StreamBridge;
+
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+/**
+ * org.egovframe.cloud.reserveitemservice.service.reserveItem.ReserveItemServiceTest
+ *
+ * 예약 물품 service 재고 변경 회귀 테스트
+ *
+ * <pre>
+ * updateInventory 가 재고를 이중으로 차감하던 결함(같은 reserveQty 만큼만 차감되어야 함)에 대한 회귀 검증.
+ * </pre>
+ */
+@ExtendWith(MockitoExtension.class)
+class ReserveItemServiceTest {
+
+    @Mock
+    private ReserveItemRepository reserveItemRepository;
+
+    @Mock
+    private StreamBridge streamBridge;
+
+    @InjectMocks
+    private ReserveItemService reserveItemService;
+
+    private ReserveItem reserveItemWithInventory(int inventoryQty) {
+        return ReserveItem.builder()
+            .reserveItemId(1L)
+            .reserveItemName("test")
+            .categoryId("education")
+            .totalQty(100)
+            .inventoryQty(inventoryQty)
+            .build();
+    }
+
+    @Test
+    void updateInventory_재고는_reserveQty_만큼만_차감된다() {
+        ReserveItem reserveItem = reserveItemWithInventory(100);
+        when(reserveItemRepository.findById(anyLong())).thenReturn(Mono.just(reserveItem));
+        ArgumentCaptor<ReserveItem> captor = ArgumentCaptor.forClass(ReserveItem.class);
+        when(reserveItemRepository.save(captor.capture()))
+            .thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+
+        StepVerifier.create(reserveItemService.updateInventory(1L, 10))
+            .expectNext(true)
+            .verifyComplete();
+
+        // 100 - 10 = 90 이어야 한다. 결함 시에는 100 - (100-10) = 10 으로 덮어써진다.
+        assertThat(captor.getValue().getInventoryQty()).isEqualTo(90);
+    }
+
+    @Test
+    void updateInventory_재고가_부족하면_차감하지_않고_false() {
+        ReserveItem reserveItem = reserveItemWithInventory(5);
+        when(reserveItemRepository.findById(anyLong())).thenReturn(Mono.just(reserveItem));
+
+        StepVerifier.create(reserveItemService.updateInventory(1L, 10))
+            .expectNext(false)
+            .verifyComplete();
+
+        // oversell 방지: 재고 부족 시 저장이 일어나지 않아야 한다.
+        verify(reserveItemRepository, never()).save(any(ReserveItem.class));
+        assertThat(reserveItem.getInventoryQty()).isEqualTo(5);
+    }
+
+    @Test
+    void updateInventory_재고와_요청수량이_같으면_0으로_차감된다() {
+        ReserveItem reserveItem = reserveItemWithInventory(10);
+        when(reserveItemRepository.findById(anyLong())).thenReturn(Mono.just(reserveItem));
+        ArgumentCaptor<ReserveItem> captor = ArgumentCaptor.forClass(ReserveItem.class);
+        when(reserveItemRepository.save(captor.capture()))
+            .thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+
+        StepVerifier.create(reserveItemService.updateInventory(1L, 10))
+            .expectNext(true)
+            .verifyComplete();
+
+        assertThat(captor.getValue().getInventoryQty()).isEqualTo(0);
+    }
+}


### PR DESCRIPTION
## 문제

`ReserveItemService.updateInventory`가 재고를 두 번 차감합니다. 호출부에서 이미 차감을 끝낸 값 `qty = inventoryQty - reserveQty`를 도메인 메서드 `updateInventoryQty()`에 넘기는데, 도메인 내부 `calcInventoryQty`가 받은 값에서 `reserveQty`를 한 번 더 뺍니다. 그래서 재고가 `reserveQty` 값으로 덮어써집니다.

재고 100, 예약 수량 10이면 90이 남아야 하지만 실제로는 10이 됩니다. 재고 80이 사라집니다. 반대로 예약 수량이 재고보다 크면 음수 가드를 우회해 oversell이 일어나고, 취소 경로(`conversionReserveQty`가 음수)에서는 재고가 음수로 떨어집니다.

이 메서드는 관리자 예약의 생성·승인·수정·취소 직전 경로에서 호출됩니다. REST `PUT /api/v1/reserve-items/{id}/inventories`와 reserve-check 서비스의 Feign 호출이 모두 이 지점을 지납니다.

## 원인

같은 클래스의 형제 메서드 `updateInventoryThenSendMessage`와 `validate`는 `updateInventoryQty(reserveQty)`로 차감 수량을 그대로 넘깁니다. `updateInventory`만 차감 완료값을 넘겨 도메인의 차감 의미와 어긋났습니다. 동일 모듈 안에서 한 호출부만 규칙을 벗어난 형태입니다.

## 변경 내용

- `updateInventoryQty(qty)` → `updateInventoryQty(reserveQty)`. 도메인이 차감을 수행하도록 차감 수량을 넘깁니다.
- 음수 재고 가드는 차감 결과값 `qty`를 그대로 검사하므로 손대지 않았습니다. 취소 경로의 음수 재고 결함도 같이 해소됩니다.

## 테스트

`ReserveItemServiceTest` 단위 테스트 3건을 추가했습니다.

- 정상 차감: 재고 100, 예약 10 → 90
- oversell 거부: 재고 5, 예약 10 → `false` 반환, 저장 호출 없음
- 경계: 재고 10, 예약 10 → 0

수정 전 코드에서는 정상 차감과 경계 테스트가 실패하고(재고가 10, 0이 아닌 값으로 덮어써짐), 수정 후 3건 모두 통과합니다. RED→GREEN을 확인했습니다.

## 빌드 전제 (별도 커밋)

reserve-item-service는 `egovframe-cloud-module-common` 경유로 `egovframe-rte-fdl-logging`(log4j-slf4j2-impl)이 유입되어 `log4j-to-slf4j`와 충돌(`cannot be present with`)하는 상태였고, 이 때문에 모듈 테스트가 전혀 실행되지 않았습니다. 형제 서비스(board/portal/user/reserve-request/reserve-check)와 동일하게 해당 모듈을 exclude했습니다. 이 exclude가 없으면 위 테스트를 실행할 수 없어 같은 PR에 포함했습니다.

## 영향 범위

- 변경 파일: reserve-item-service의 `ReserveItemService.java`(1줄), `build.gradle`(exclude 1줄), 신규 테스트 1개.
- API 시그니처·DB 스키마 변경 없음. 재고 차감 결과값만 정상화됩니다.
- CWE-682(잘못된 계산) 유형에 해당합니다.
