### PR TITLE
fix: 포털 메인 배너·게시판 목록이 비어 있을 때 거대한 빈 공백이 생기는 레이아웃 결함 수정

### DIFF
--- a/frontend/portal/public/styles/lg/layout.css
+++ b/frontend/portal/public/styles/lg/layout.css
@@ -1108,6 +1108,11 @@ footer div > span a {
   height: 700px;
   text-align: center;
 }
+/* 배너 데이터가 없어 슬라이드가 하나도 없을 때 빈 컨테이너가 고정 높이만큼 공백을 차지하지 않도록 함 */
+.slideBox .swiper-container:empty {
+  display: none;
+  height: 0;
+}
 
 #main .slideBox .swiper-slide-active {
   opacity: 1;
@@ -1692,7 +1697,8 @@ footer div > span a {
   position: relative;
   display: flex;
   width: 100%;
-  height: 345px;
+  min-height: 80px;
+  height: auto;
 }
 #main .notice ul:first-child {
   margin-right: 120px;

--- a/frontend/portal/public/styles/sm/layout.css
+++ b/frontend/portal/public/styles/sm/layout.css
@@ -1093,7 +1093,14 @@ footer div > span a {
 .swiper-container {
   padding-top: 15px;
   position: relative;
-  height: 50vw;
+  height: auto;
+  max-height: 50vw;
+}
+/* 배너 데이터가 없어 슬라이드가 하나도 없을 때 빈 컨테이너가 고정 높이만큼 공백을 차지하지 않도록 함 */
+.swiper-container:empty {
+  display: none;
+  height: 0;
+  padding: 0;
 }
 #main .slide {
   height: 43vw;
@@ -1323,7 +1330,8 @@ footer div > span a {
   position: relative;
   display: flex;
   width: 100%;
-  height: 450px;
+  min-height: 80px;
+  height: auto;
   justify-content: center;
 }
 #main .notice ul li {


### PR DESCRIPTION
## 변경 사유

배너 데이터나 게시판 목록이 비어 있는 상태(초기 데이터가 아직 없는 환경 등)에서 메인 페이지 헤더 아래에 거대한 빈 공백이 생기는 현상을 소스 코드 흐름 분석으로 확인했습니다.

## 원인

`MainSM.tsx`/`MainLG.tsx`는 배너 목록을 `banners[bannerTypeCodes[0]]?.map(...)`로 만든 뒤 그 결과를 `mainBanners` state에 저장하고, `{mainBanners && (<CustomSwiper>...)}` 형태로 렌더링합니다. 이때 `banners`는 있지만 해당 배너 타입 배열이 비어 있으면 `mainBanners`는 `undefined`가 아니라 **빈 배열(`[]`)** 이 되는데, 빈 배열은 JS에서 truthy이므로 `<CustomSwiper>`가 슬라이드 0개인 채로 그대로 렌더링됩니다. 이 상태에서 `.swiper-container`에 걸린 고정 높이(`50vw`/`700px`)가 콘텐츠 없이 그대로 적용되어 빈 박스가 생깁니다. 게시판 탭의 `#main .notice ul`도 동일한 이유(고정 `height: 450px`/`345px`)로 목록이 비어 있으면 빈 공백을 차지합니다.

## 변경 내용 (CSS만, 다른 변경 없음)

- `sm/layout.css`, `lg/layout.css`의 `.swiper-container`(또는 `.slideBox .swiper-container`): 고정 높이를 유연한 높이로 바꾸고, 슬라이드가 하나도 없을 때(`:empty`) 컨테이너 자체를 숨기도록 추가.
- `sm/layout.css`, `lg/layout.css`의 `#main .notice ul`: 고정 `height`를 `min-height`+`height: auto`로 전환해 목록이 비어 있어도 불필요한 공백을 차지하지 않도록 함.

## 스코프 참고

이번 조사 과정에서 헤더 높이·메뉴 줄 높이·섹션 여백 등을 더 컴팩트하게 줄이는 것이 나아 보인다는 의견도 있었으나, 이는 객관적 결함이 아니라 디자인 취향의 영역이라 판단해 **이번 PR에는 포함하지 않았습니다**. 순수하게 "데이터가 비어 있을 때 레이아웃이 깨지는" 결함만 다룹니다.

## 검증

- 관련 컴포넌트(`MainSM.tsx`, `MainLG.tsx`)의 조건부 렌더링 로직을 직접 추적해 원인을 특정했습니다.
- 이 환경에 브라우저 자동화 도구가 연결되어 있지 않아, 실제 실행 중인 화면에서의 라이브 스크린샷 검증은 수행하지 못했습니다 — 정직하게 밝힙니다. CSS 문법 자체는 유효하며 변경 범위는 위 두 규칙으로 한정되어 있어 다른 레이아웃에 영향을 줄 가능성은 낮다고 판단하나, 리뷰 시 실제 빈 데이터 상태에서 시각 확인을 권장합니다.

- [ ] 단일 주제만 다룸 (CSS 결함 수정만, 디자인 변경 없음)
- [ ] 기존 동작에 영향 없음 (데이터가 있을 때는 기존과 동일하게 렌더링되며, 비어 있을 때만 공백이 사라짐)