### PR TITLE
fix: MenuSideResponseDto.hasChildren의 논리 연산자 오류 수정 (NPE 방지)

### DIFF
--- a/backend/portal-service/src/main/java/org/egovframe/cloud/portalservice/api/menu/dto/MenuSideResponseDto.java
+++ b/backend/portal-service/src/main/java/org/egovframe/cloud/portalservice/api/menu/dto/MenuSideResponseDto.java
@@ -1,15 +1,14 @@
 package org.egovframe.cloud.portalservice.api.menu.dto;
 
+import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.egovframe.cloud.portalservice.domain.menu.Menu;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
-import org.egovframe.cloud.portalservice.domain.menu.Menu;
-
-import java.util.List;
-import java.util.stream.Collectors;
-import org.egovframe.cloud.portalservice.domain.menu.MenuRole;
 
 /**
  * org.egovframe.cloud.portalservice.api.menu.dto.MenuSideResponseDto
@@ -84,7 +83,7 @@ public class MenuSideResponseDto {
     }
 
     public boolean hasChildren() {
-        return Objects.nonNull(children) || children.size() > 0;
+        return Objects.nonNull(children) && !children.isEmpty();
     }
 
     public boolean isRequiredUrlPath() {


### PR DESCRIPTION
## 수정 사유

portal-service의 `MenuSideResponseDto.hasChildren()`이 논리합(`||`)으로 잘못 구성되어 있습니다.

```java
public boolean hasChildren() {
    return Objects.nonNull(children) || children.size() > 0;
}
```

- `children`이 **null**이면: 좌항이 false → 우항 `children.size()`가 평가되어 **NullPointerException**이 발생합니다.
- `children`이 **빈 목록**이면: 좌항이 true → `hasChildren()`이 **true**를 반환합니다(의미상 오류).

## 수정 내용

```java
return Objects.nonNull(children) && !children.isEmpty();
```

- null → false (NPE 제거), 빈 목록 → false, 자식 있음 → true 로 의도된 의미와 일치합니다.
- 호출부는 `MenuRoleService.recursiveSetUrlPath()`의 `if (!hasChildren()) return;` 1곳으로, 수정 후 동작은 null·빈 목록에서 안전하게 재귀를 중단하며 자식이 있는 경우는 기존과 동일합니다.

## 테스트 여부

- [x] portal-service 로컬 `gradlew compileJava` 통과 (JDK 17)
- [x] 호출부 전수 확인 (backend 1곳, frontend의 hasChildren은 별개 TS 필드)
