### PR TITLE
chore: 백엔드 주석 한글 표기 오타 수정 (메세지→메시지, 비지니스→비즈니스, 갯수→개수)

### DIFF
--- a/backend/apigateway/src/main/java/org/egovframe/cloud/apigateway/config/MessageSourceConfig.java
+++ b/backend/apigateway/src/main/java/org/egovframe/cloud/apigateway/config/MessageSourceConfig.java
@@ -57,8 +57,8 @@ public class MessageSourceConfig {
         }
         messageSource.getBasenameSet().forEach(s -> log.info("messageSource getBasenameSet={}", s));
 
-        messageSource.setCacheSeconds(60); // 메세지 파일 변경 감지 간격
-        messageSource.setUseCodeAsDefaultMessage(true); // 메세지가 없으면 코드를 메세지로 한다
+        messageSource.setCacheSeconds(60); // 메시지 파일 변경 감지 간격
+        messageSource.setUseCodeAsDefaultMessage(true); // 메시지가 없으면 코드를 메시지로 한다
         messageSource.setDefaultEncoding(StandardCharsets.UTF_8.name());
         return messageSource;
     }

--- a/backend/board-service/src/main/java/org/egovframe/cloud/boardservice/service/posts/PostsService.java
+++ b/backend/board-service/src/main/java/org/egovframe/cloud/boardservice/service/posts/PostsService.java
@@ -362,7 +362,7 @@ public class PostsService extends AbstractService {
      * @param postsNo 게시물 번호
      * @param userId  사용자 id
      * @return Posts 게시물 엔티티
-     * @throws BusinessMessageException 비지니스 예외
+     * @throws BusinessMessageException 비즈니스 예외
      */
     private Posts findPostsByCreatedBy(Integer boardNo, Integer postsNo, String userId) throws BusinessMessageException {
         if (userId == null || "".equals(userId)) {
@@ -384,7 +384,7 @@ public class PostsService extends AbstractService {
      * 게시판 사용자 작성 여부 확인
      *
      * @param boardNo 게시판 번호
-     * @throws BusinessMessageException 비지니스 예외
+     * @throws BusinessMessageException 비즈니스 예외
      */
     private void checkUserWritable(Integer boardNo) throws BusinessMessageException {
         BoardResponseDto board = boardService.findById(boardNo);
@@ -395,7 +395,7 @@ public class PostsService extends AbstractService {
     }
 
     /**
-     * 첨부파일 entity 정보 업데이트 하기 위해 이벤트 메세지 발행
+     * 첨부파일 entity 정보 업데이트 하기 위해 이벤트 메시지 발행
      *
      * @param entity
      */

--- a/backend/egovframe-cloud-module-common/src/main/java/org/egovframe/cloud/common/config/MessageSourceConfig.java
+++ b/backend/egovframe-cloud-module-common/src/main/java/org/egovframe/cloud/common/config/MessageSourceConfig.java
@@ -63,8 +63,8 @@ public class MessageSourceConfig {
 
         messageSource.getBasenameSet().forEach(s -> log.info("messageSource getBasenameSet={}", s));
 
-        messageSource.setCacheSeconds(60); // 메세지 파일 변경 감지 간격
-        messageSource.setUseCodeAsDefaultMessage(true); // 메세지가 없으면 코드를 메세지로 한다
+        messageSource.setCacheSeconds(60); // 메시지 파일 변경 감지 간격
+        messageSource.setUseCodeAsDefaultMessage(true); // 메시지가 없으면 코드를 메시지로 한다
         messageSource.setDefaultEncoding(StandardCharsets.UTF_8.name());
 
         return messageSource;

--- a/backend/egovframe-cloud-module-common/src/main/java/org/egovframe/cloud/common/service/AbstractService.java
+++ b/backend/egovframe-cloud-module-common/src/main/java/org/egovframe/cloud/common/service/AbstractService.java
@@ -48,7 +48,7 @@ public abstract class AbstractService extends EgovAbstractServiceImpl {
 
     /**
      * 게시물 저장 후 해당 정보를 첨부파일 entity에 입력하기 위해
-     * 이벤트 메세지 발행
+     * 이벤트 메시지 발행
      */
     protected void sendAttachmentEntityInfo(StreamBridge streamBridge, AttachmentEntityMessage entityMessage) {
         streamBridge.send(ATTACHMENT_ENTITY_BINDING_NAME, MessageBuilder.withPayload(entityMessage).build());

--- a/backend/portal-service/src/main/java/org/egovframe/cloud/portalservice/service/banner/BannerService.java
+++ b/backend/portal-service/src/main/java/org/egovframe/cloud/portalservice/service/banner/BannerService.java
@@ -131,7 +131,7 @@ public class BannerService extends AbstractService {
 
         Banner entity = bannerRepository.save(requestDto.toEntity(site));
 
-        //첨부파일 entity 정보 업데이트 하기 위해 이벤트 메세지 발행
+        //첨부파일 entity 정보 업데이트 하기 위해 이벤트 메시지 발행
         sendAttachment(entity);
 
         return new BannerResponseDto(entity);

--- a/backend/reserve-check-service/src/main/java/org/egovframe/cloud/reservechecksevice/validator/ReserveSaveValidator.java
+++ b/backend/reserve-check-service/src/main/java/org/egovframe/cloud/reservechecksevice/validator/ReserveSaveValidator.java
@@ -50,7 +50,7 @@ public class ReserveSaveValidator implements ConstraintValidator<ReserveSaveVali
     }
 
     /**
-     * 예약 신청 시 비지니스 로직에 의한 validation check
+     * 예약 신청 시 비즈니스 로직에 의한 validation check
      *
      * @param value
      * @param context

--- a/backend/reserve-item-service/src/main/java/org/egovframe/cloud/reserveitemservice/api/reserveItem/ReserveItemApiController.java
+++ b/backend/reserve-item-service/src/main/java/org/egovframe/cloud/reserveitemservice/api/reserveItem/ReserveItemApiController.java
@@ -180,9 +180,9 @@ public class ReserveItemApiController {
 
     /**
      * 각 카테고리별 최신 예약 물품 조회
-     * 파라미터로 받는 갯수만큼 조회한다.
+     * 파라미터로 받는 개수만큼 조회한다.
      *
-     * @param count 조회할 갯수 0:전체
+     * @param count 조회할 개수 0:전체
      * @return
      */
     @GetMapping("/api/v1/reserve-items/latest/{count}")

--- a/backend/reserve-item-service/src/main/java/org/egovframe/cloud/reserveitemservice/domain/reserveItem/ReserveItemRepositoryImpl.java
+++ b/backend/reserve-item-service/src/main/java/org/egovframe/cloud/reserveitemservice/domain/reserveItem/ReserveItemRepositoryImpl.java
@@ -95,7 +95,7 @@ public class ReserveItemRepositoryImpl implements ReserveItemRepositoryCustom{
     /**
      * 카테고리별 예약 물품 최신 데이터 count 만큼 조회
      *
-     * @param count         조회할 갯수 0:전체
+     * @param count         조회할 개수 0:전체
      * @param categoryId    카테고리 아이디
      * @return
      */

--- a/backend/reserve-item-service/src/main/java/org/egovframe/cloud/reserveitemservice/service/reserveItem/ReserveItemService.java
+++ b/backend/reserve-item-service/src/main/java/org/egovframe/cloud/reserveitemservice/service/reserveItem/ReserveItemService.java
@@ -216,9 +216,9 @@ public class ReserveItemService extends ReactiveAbstractService {
 
     /**
      * 각 카테고리별 최신 예약 물품 조회
-     * 파라미터로 받는 갯수만큼 조회한다.
+     * 파라미터로 받는 개수만큼 조회한다.
      *
-     * @param count 조회할 갯수 0:전체
+     * @param count 조회할 개수 0:전체
      * @return
      */
     public Mono<Map<String, Collection<ReserveItemMainResponseDto>>> findLatest(Integer count) {

--- a/backend/reserve-item-service/src/main/java/org/egovframe/cloud/reserveitemservice/validator/ReserveItemSaveValidator.java
+++ b/backend/reserve-item-service/src/main/java/org/egovframe/cloud/reserveitemservice/validator/ReserveItemSaveValidator.java
@@ -47,7 +47,7 @@ public class ReserveItemSaveValidator implements ConstraintValidator<ReserveItem
     }
 
     /**
-     * 예약 물품 저장 시 비지니스 로직에 의한 validation check
+     * 예약 물품 저장 시 비즈니스 로직에 의한 validation check
      *
      * @param value
      * @param context


### PR DESCRIPTION
## 변경 내용

백엔드 소스의 주석 내 한글 표기 오타를 표준 표기로 수정했습니다. 코드 동작·식별자·문자열 리터럴 변경은 없으며(주석만), 테스트 코드는 메서드명에 해당 단어가 쓰인 경우가 있어 제외했습니다.

- 메세지 → 메시지 (apigateway·module-common MessageSourceConfig, AbstractService, PostsService, BannerService)
- 비지니스 → 비즈니스 (PostsService, ReserveSaveValidator, ReserveItemSaveValidator)
- 갯수 → 개수 (ReserveItemApiController, ReserveItemRepositoryImpl, ReserveItemService)

총 10개 파일, 주석 16줄 (+16 −16). 같은 계열로 egovframe-common-components #1090, template-simple-backend #163이 병합된 바 있습니다.

## 검증

- 주석 외 변경 없음(식별자·문자열 변경 0) — 전체 diff가 주석 라인임을 확인
- 빌드 영향 없음 (주석 전용 변경)