### PR TITLE
hotfix: board-service 가 빌드되지 않는 build.gradle 문법 오류 수정

### DIFF
--- a/backend/board-service/build.gradle
+++ b/backend/board-service/build.gradle
@@ -14,7 +14,7 @@ configurations {
     compileOnly {
         extendsFrom annotationProcessor
     }
-}https://github.com/eGovFramework/egovframe-msa-edu/pull/83/conflict?name=backend%252Fboard-service%252Fsrc%252Ftest%252Fjava%252Forg%252Fegovframe%252Fcloud%252Fboardservice%252Fservice%252Fposts%252FPostsServiceTest.java&base_oid=b00134c887002d1b45a1838c9969cc215e8a87d1&head_oid=f0766c80f5024db512416c7cd3133b3b886943a6
+}
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
> **현재 `main`에서 board-service 가 빌드되지 않습니다.** `build.gradle` 17행의 문법 오류로 Gradle 빌드 스크립트 컴파일 단계에서 중단되어, 어떤 태스크도 실행할 수 없습니다. 의존성 해석이나 Java 컴파일에 도달하지 못합니다. 우선 처리를 요청드립니다.
>
> ```
> cd backend/board-service && ./gradlew build
> build file 'build.gradle': 17: Unexpected input: ':' @ line 17, column 7.
> BUILD FAILED in 391ms
> ```

## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

### 한 줄 요약

`backend/board-service/build.gradle` 17행 닫는 중괄호 뒤에 URL 문자열이 붙어 있어 Groovy 파서가 빌드 스크립트를 컴파일하지 못합니다. 해당 문자열만 제거했습니다.

### 1. 현재 상태

```
15|     compileOnly {
16|         extendsFrom annotationProcessor
17|     }
18| }https://github.com/eGovFramework/egovframe-msa-edu/pull/83/conflict?name=backend%252F…
19|
20| repositories {
```

`}` 뒤의 `https:` 콜론에서 파싱이 실패합니다. 빌드 스크립트 자체가 컴파일되지 않으므로 `help`·`compileJava`·`test`·`build` 등 모든 태스크가 동일하게 중단됩니다.

10개 서비스가 각각 독립 Gradle 프로젝트인 구조에서, 이 문제는 board-service 하나에만 있습니다. 같은 명령을 다른 서비스에 실행하면 정상 동작합니다.

| 서비스 | `./gradlew help` |
|---|---|
| `apigateway` | BUILD SUCCESSFUL |
| `board-service` | **BUILD FAILED** (문법 오류) |

`*.gradle`·`*.yml`·`*.java`를 전수 검사해 동일한 패턴이 다른 파일에 없음을 확인했습니다.

### 2. 언제부터인가

`git bisect` 대신 커밋을 직접 지목해 전후를 빌드하여 확인했습니다.

| 대상 | 커밋 | 결과 |
|---|---|---|
| [#83](https://github.com/eGovFramework/egovframe-msa-edu/pull/83) 머지 직전 `main` | [`3e4b8c5`](https://github.com/eGovFramework/egovframe-msa-edu/commit/3e4b8c5d2003650749a405481a0294b75dab958d) | **BUILD SUCCESSFUL** |
| [#83](https://github.com/eGovFramework/egovframe-msa-edu/pull/83) 머지 커밋 | [`fa16092`](https://github.com/eGovFramework/egovframe-msa-edu/commit/fa1609246481d8039c67d2091b3432e9b9f9a116) | **BUILD FAILED** |
| 현재 `main` | [`3d406da`](https://github.com/eGovFramework/egovframe-msa-edu/commit/3d406da3a97f134c0086fa7a58e0d3804ef24f5b) | **BUILD FAILED** |

[#83](https://github.com/eGovFramework/egovframe-msa-edu/pull/83) 머지 시점(2026-07-30T01:09:29Z)부터 발생했고, 이후 `main`에 21개 커밋이 들어오는 동안 유지되고 있습니다.

문자열이 유입된 곳은 [#83](https://github.com/eGovFramework/egovframe-msa-edu/pull/83)의 두 번째 커밋 [`7a0e1de`](https://github.com/eGovFramework/egovframe-msa-edu/commit/7a0e1de091f98ec8aec1591254ad4d83134d7579)(`Merge branch 'main' into fix/posts-newest-order`)입니다. **이 커밋의 두 부모 모두 해당 문자열을 갖고 있지 않습니다.**

| 커밋 | 문자열 |
|---|---|
| [`eb6f95b`](https://github.com/eGovFramework/egovframe-msa-edu/commit/eb6f95b31d9dd989a89bd34dbc04b4b350f76027) (PR 브랜치) | 없음 |
| [`3e4b8c5`](https://github.com/eGovFramework/egovframe-msa-edu/commit/3e4b8c5d2003650749a405481a0294b75dab958d) (당시 `main`) | 없음 |
| [`7a0e1de`](https://github.com/eGovFramework/egovframe-msa-edu/commit/7a0e1de091f98ec8aec1591254ad4d83134d7579) (머지 결과) | **있음** |

즉 병합 자체에서 생긴 것으로, 어느 한쪽 브랜치에서 넘어온 변경이 아닙니다. 문자열이 가리키는 주소가 [#83](https://github.com/eGovFramework/egovframe-msa-edu/pull/83)의 충돌 해결 화면이므로, 병합 과정에서 편집기에 들어간 것으로 보입니다.

### 3. 수정 내용

17행의 URL 문자열만 제거했습니다.

```diff
-}https://github.com/eGovFramework/egovframe-msa-edu/pull/83/conflict?name=…
+}
```

같은 병합에서 `configurations.testRuntimeClasspath` 블록이 `systemProperty 'slf4j.provider'` 방식으로 교체된 변경도 있으나, **그쪽은 의도된 충돌 해결로 판단해 손대지 않았습니다.** 이 PR은 문법 오류 하나만 다룹니다.

### 4. 영향 범위

- 변경 파일은 `backend/board-service/build.gradle` 하나이며 1줄입니다
- 의존성·플러그인·태스크 설정은 바뀌지 않았습니다. 제거한 문자열은 Groovy 문법상 유효하지 않은 토큰이므로 어떤 동작도 수행하지 않고 있었습니다
- 다른 9개 서비스는 영향을 받지 않습니다
- 현재 열려 있는 [#87](https://github.com/eGovFramework/egovframe-msa-edu/pull/87)·[#85](https://github.com/eGovFramework/egovframe-msa-edu/pull/85)가 같은 파일을 수정하지만 17행을 건드리지 않아 텍스트 충돌 없이 병합 가능합니다

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

JDK 17(Temurin 17.0.14), Gradle Wrapper 환경에서 확인했습니다.

| 태스크 | 수정 전 | 수정 후 |
|---|---|---|
| `./gradlew help` | BUILD FAILED | **BUILD SUCCESSFUL** |
| `./gradlew compileJava` | BUILD FAILED | **BUILD SUCCESSFUL** |
| `./gradlew compileTestJava` | BUILD FAILED | **BUILD SUCCESSFUL** |

### 단위 테스트 결과

`./gradlew build`를 수행한 결과 단위 테스트는 모두 통과합니다.

| 테스트 클래스 | 테스트 | 실패 |
|---|---|---|
| `service.posts.PostsServiceTest` | 1 | 0 |
| `service.board.BoardServiceTest` | 4 | 0 |
| `api.board.dto.BoardSaveRequestDtoTest` | 2 | 0 |

### 재현 절차

```
git clone https://github.com/eGovFramework/egovframe-msa-edu
cd egovframe-msa-edu/backend/board-service
./gradlew help
```

외부 의존이 필요 없습니다. 빌드 스크립트 파싱 단계에서 멈추므로 DB·Eureka·Config 서버 없이 재현됩니다.

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

빌드 스크립트만 수정했고 애플리케이션 동작과 화면은 그대로여서 브라우저에 따라 달라지는 동작이 없습니다. 그래서 별도로 선택하지 않았습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

화면 변경이 없어 첨부하지 않았습니다. 위 재현 절차의 빌드 결과로 확인하실 수 있습니다.

---


