### PR TITLE
fix: 업로드 허용 확장자에서 htm/html 제거가 배포용 설정 사본에 누락된 문제 수정

### DIFF
--- a/config/application.yml
+++ b/config/application.yml
@@ -19,7 +19,7 @@ file:
   directory: ${app.home:${user.home}}/msa-attach-volume # url 사용시에는 사용되지 않는다
   url: http://${file.hostname:localhost}:8080 # nginx 로 파일 다운로드 처리
   storage:
-    allowed-extensions: jpg,jpeg,png,gif,bmp,webp,pdf,xlsx,xls,htm,html,txt
+    allowed-extensions: jpg,jpeg,png,gif,bmp,webp,pdf,xlsx,xls,txt
     max-file-size: 10MB
 
 messages:


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

### 한 줄 요약

[NCSC&NIA 보안점검 적용](https://github.com/eGovFramework/egovframe-msa-edu/commit/c493daf15058dd361e73be178a00c6c1c5371f1f) 커밋이 업로드 허용 확장자에서 `htm,html` 을 제거했으나, 설정 사본 두 곳 중 한 곳에만 반영됐습니다. 컨테이너 배포에서 읽는 사본에는 남아 있어 `docker compose` 로 기동하면 HTML 업로드가 그대로 허용됩니다.

### 1. 설정 사본이 두 벌인 구조

Config Server 가 서비스별 설정을 배포하는 구조이고, 저장소에 같은 파일 묶음이 두 위치에 있습니다.

```
config/                    사본 A · yml 13개
backend/config/            config 서비스 Gradle 프로젝트
  └ config/                사본 B · yml 13개 (파일명 동일)
```

두 사본을 전수 대조하면 **13개 중 12개가 완전히 동일하고 `application.yml` 하나만 갈려 있습니다.** 그동안 두 사본을 함께 관리해 왔음을 보여 줍니다.

| 커밋 | 날짜 | 반영 범위 |
|---|---|---|
| [#79](https://github.com/eGovFramework/egovframe-msa-edu/pull/79) DB/Eureka 자격증명 외부화 | 2026-06-23 | 사본 A · B 모두 |
| [NCSC&NIA 보안점검 적용](https://github.com/eGovFramework/egovframe-msa-edu/commit/c493daf15058dd361e73be178a00c6c1c5371f1f) | 2026-07-24 | **사본 B만** |

### 2. 두 사본이 각각 언제 읽히는가

둘 중 한쪽이 쓰이지 않는 파일인 것은 아닙니다. `search-locations` 가 리터럴 상대경로여서 **실행 위치에 따라 다른 사본을 읽습니다.**

```yaml
# backend/config/src/main/resources/application.yml:13
search-locations: file:./config
```

| 실행 방식 | 작업 디렉토리 | `./config` 가 가리키는 곳 |
|---|---|---|
| 로컬 개발 (IDE·`gradle bootRun`) | `backend/config/` | 사본 B `backend/config/config/` |
| 컨테이너 (`docker compose`) | `/usr/app/` | 사본 A — 볼륨으로 붙은 저장소 루트 `config/` |

컨테이너 경로의 근거입니다.

```dockerfile
# backend/config/Dockerfile:10-12
ENV APP_HOME=/usr/app/
WORKDIR $APP_HOME
```

```yaml
# docker-compose/app/docker-compose.yml:9
- ${HOME}/workspace.edu/egovframe-msa-edu/config:/usr/app/config
```

로컬 실행에서는 `build.gradle` 에 `workingDir` 재정의가 없어 Gradle 기본값인 프로젝트 디렉토리가 작업 디렉토리가 되고, 그때 `./config` 는 바로 옆의 `backend/config/config/` 입니다.

따라서 **로컬에서 개발할 때는 차단되고, 컨테이너로 배포하면 허용되는 상태**입니다.

### 3. 차단이 의도였음

`FileStorageUtils` 의 하드코딩 기본값에도 `htm/html` 이 없습니다. [같은 커밋](https://github.com/eGovFramework/egovframe-msa-edu/commit/c493daf15058dd361e73be178a00c6c1c5371f1f)이 이 파일도 함께 수정했습니다.

```java
// FileStorageUtils.java:85
String raw = environment.getProperty(PROPERTY_ALLOWED_EXTENSIONS,
        "jpg,jpeg,png,gif,bmp,webp,pdf,xlsx,xls,txt");
```

설정 파일이 존재하면 이 기본값을 덮어쓰므로, 컨테이너에서는 기본값이 적용되지 않습니다.

### 4. 수정 내용

사본 A 의 22행에서 `htm,html` 을 제거했습니다.

```diff
-    allowed-extensions: jpg,jpeg,png,gif,bmp,webp,pdf,xlsx,xls,htm,html,txt
+    allowed-extensions: jpg,jpeg,png,gif,bmp,webp,pdf,xlsx,xls,txt
```

수정 후 두 사본의 `application.yml` 이 완전히 동일해집니다. 결과적으로 13개 파일 전부가 일치합니다.

### 5. 영향 범위

- 변경 파일은 `config/application.yml` 하나이며 1줄입니다
- 허용 확장자 외 다른 설정은 바뀌지 않았습니다
- 로컬 개발 경로의 동작은 변하지 않습니다. 이미 같은 값이었습니다
- 이 파일을 수정하는 오픈 PR 은 없습니다

범위 밖으로 남겨 둔 사항이 하나 있습니다. `search-locations` 가 `${search.location:file:./config}` 형태가 아니라 리터럴이므로, `Dockerfile:18` 의 `-Dsearch.location` 과 `docker-compose.yml:14` 의 `SEARCH_LOCATION` 환경변수가 실제로는 적용되지 않습니다. 현재는 세 곳이 같은 경로를 지정하고 있어 동작에 차이가 없습니다. 동작 변경이 되므로 이번 PR 에서는 다루지 않았습니다.

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

설정 파일 변경이라 단위 테스트 대상이 아닙니다. 대신 **Config Server 를 실제로 기동해 내려주는 값을 조회**했습니다.

공개 이미지를 그대로 사용하고, 마운트할 디렉토리만 바꿔 두 사본을 대조했습니다.

```
docker run -d -p 8899:8888 \
  -v "$PWD/config:/usr/app/config" \
  -e SPRING_PROFILES_ACTIVE=native -e ENCRYPT_KEY=token_secret \
  egovframe/msa-edu-config:latest

curl -s http://localhost:8899/board-service/native
```

응답의 `propertySources` 에서 `file.storage.allowed-extensions` 값을 확인한 결과입니다.

| 마운트한 디렉토리 | Config Server 가 내려준 값 |
|---|---|
| `config/` (수정 전) | `…,xlsx,xls,`**`htm,html`**`,txt` |
| `backend/config/config/` | `…,xlsx,xls,txt` |
| `config/` (**수정 후**) | `…,xlsx,xls,txt` |

마운트 대상만 바꾸면 값이 달라지는 것까지 확인했으므로, 어느 사본이 읽히는지는 추론이 아니라 측정 결과입니다.

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

서버 측 업로드 허용 목록 설정이라 브라우저에 따라 달라지는 동작이 없습니다. 그래서 별도로 선택하지 않았습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

화면 변경이 없어 첨부하지 않았습니다. 위 Config Server 조회 결과로 확인하실 수 있습니다.

