### PR TITLE
fix: 다국어 메시지 프로퍼티 폴더 생성 실패와 미저장 파일 업로드 수정

### DIFF
--- a/backend/portal-service/src/main/java/org/egovframe/cloud/portalservice/config/MessageSourceFiles.java
+++ b/backend/portal-service/src/main/java/org/egovframe/cloud/portalservice/config/MessageSourceFiles.java
@@ -70,7 +70,7 @@ public class MessageSourceFiles {
         // 메시지 폴더 경로
         final String fileMessagesDirectory = StringUtils.cleanPath(environment.getProperty("file.directory") + "/messages");
         try {
-            Files.createDirectory(Paths.get(fileMessagesDirectory).toAbsolutePath().normalize());
+            Files.createDirectories(Paths.get(fileMessagesDirectory).toAbsolutePath().normalize());
         } catch (FileAlreadyExistsException e) {
             log.info("메시지 폴더 경로에 파일이나 디렉토리가 이미 존재");
         } catch (IOException e) {
@@ -99,12 +99,11 @@ public class MessageSourceFiles {
 
             try (FileOutputStream out = new FileOutputStream(propFile)) {
                 prop.store(out, "messages");
+                // 저장에 성공한 파일만 업로드 대상에 담는다
+                files.add(propFile);
             } catch (IOException e) {
                 log.error("Messages FileOutputStream IOException", e);
             }
-
-            // files
-            files.add(propFile);
         }
 
         String ftpEnabled = environment.getProperty("ftp.enabled");

--- a/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/config/MessageSourceFilesTest.java
+++ b/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/config/MessageSourceFilesTest.java
@@ -1,0 +1,96 @@
+package org.egovframe.cloud.portalservice.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Properties;
+
+import org.egovframe.cloud.portalservice.domain.message.Message;
+import org.egovframe.cloud.portalservice.domain.message.MessageRepository;
+import org.egovframe.cloud.portalservice.utils.StorageUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+import org.springframework.mock.env.MockEnvironment;
+
+/**
+ * {@link MessageSourceFiles}의 메시지 프로퍼티 생성 동작을 검증한다.
+ *
+ * <p>Spring 컨텍스트 없이 저장소·스토리지를 대역으로 두고 임시 디렉터리에 파일을 만든다.
+ */
+class MessageSourceFilesTest {
+
+    private static final List<Message> MESSAGES = List.of(
+            Message.builder().messageId("common.login").messageKoName("로그인").messageEnName("Login").build());
+
+    private MessageSourceFiles messageSourceFiles(String fileDirectory, StorageUtils storageUtils) {
+        MessageRepository messageRepository = mock(MessageRepository.class);
+        when(messageRepository.findAll()).thenReturn(MESSAGES);
+
+        MockEnvironment environment = new MockEnvironment();
+        environment.setProperty("file.directory", fileDirectory);
+        environment.setProperty("ftp.enabled", "true");
+
+        return new MessageSourceFiles(messageRepository, environment, storageUtils);
+    }
+
+    @Test
+    @DisplayName("file.directory가 아직 없어도 하위 messages 폴더까지 만들고 프로퍼티를 저장한다")
+    void createsMessagesDirectoryWhenParentIsAbsent(@TempDir Path tempDir) throws Exception {
+        Path fileDirectory = tempDir.resolve("upload").resolve("portal");
+        assertThat(Files.exists(fileDirectory)).isFalse();
+        StorageUtils storageUtils = mock(StorageUtils.class);
+
+        int count = messageSourceFiles(fileDirectory.toString(), storageUtils).create();
+
+        assertThat(count).isEqualTo(MESSAGES.size());
+        Path messagesDirectory = fileDirectory.resolve("messages");
+        assertThat(messagesDirectory).exists();
+        for (String lang : new String[]{"", "_ko", "_en"}) {
+            assertThat(messagesDirectory.resolve("messages" + lang + ".properties")).exists();
+        }
+
+        Properties saved = new Properties();
+        try (var in = Files.newInputStream(messagesDirectory.resolve("messages_en.properties"))) {
+            saved.load(in);
+        }
+        assertThat(saved.getProperty("common.login")).isEqualTo("Login");
+    }
+
+    @Test
+    @DisplayName("저장에 실패하면 존재하지 않는 파일을 업로드 대상에 넣지 않는다")
+    void doesNotUploadFilesThatWereNotWritten(@TempDir Path tempDir) throws Exception {
+        Path fileDirectory = Files.createDirectories(tempDir.resolve("upload"));
+        // messages 를 폴더가 아닌 일반 파일로 선점해 폴더 생성과 파일 저장을 모두 실패시킨다
+        Files.createFile(fileDirectory.resolve("messages"));
+        StorageUtils storageUtils = mock(StorageUtils.class);
+
+        messageSourceFiles(fileDirectory.toString(), storageUtils).create();
+
+        verify(storageUtils, never()).storeFiles(anyList(), anyString());
+    }
+
+    @Test
+    @DisplayName("업로드 대상에는 실제로 저장된 파일만 담긴다")
+    void uploadsOnlyStoredFiles(@TempDir Path tempDir) {
+        Path fileDirectory = tempDir.resolve("upload");
+        StorageUtils storageUtils = mock(StorageUtils.class);
+
+        messageSourceFiles(fileDirectory.toString(), storageUtils).create();
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<File>> captor = ArgumentCaptor.forClass(List.class);
+        verify(storageUtils).storeFiles(captor.capture(), anyString());
+        assertThat(captor.getValue()).hasSize(3).allSatisfy(file -> assertThat(file).exists());
+    }
+}


### PR DESCRIPTION
## 변경 이유

`MessageSourceFiles.create()`는 서비스 기동 시 DB의 메시지를 읽어 `messages/messages{lang}.properties` 세 개를 만듭니다. 이 경로에 결함이 두 개 있습니다.

**1. 부모 경로가 없으면 폴더 생성이 실패합니다.**

```java
Files.createDirectory(Paths.get(fileMessagesDirectory).toAbsolutePath().normalize());
```

`Files.createDirectory`는 부모 경로가 없으면 `NoSuchFileException`을 던집니다. 여기서 만들려는 경로는 `file.directory + "/messages"`이므로 `file.directory`가 먼저 있어야 합니다.

`file.directory`를 만드는 곳은 `FileStorageUtils` 하나뿐이고(107행 `Files.createDirectories`), 그마저 ftp 비활성일 때만 실행됩니다(104~106행). ftp를 쓰는 환경에서는 `StorageConfig`가 `FtpStorageUtils`를 고르므로 로컬에 `file.directory`가 생기지 않습니다. 그 상태에서 폴더 생성이 실패하고, 이어지는 `new FileOutputStream(propFile)`도 `FileNotFoundException`으로 실패합니다. 두 예외 모두 잡아서 로그만 남기므로 기동은 정상으로 보이지만 **메시지 프로퍼티 파일이 하나도 만들어지지 않습니다.**

같은 서비스의 `FileStorageUtils`는 두 곳 모두 `createDirectories`를 씁니다. 이 파일만 `createDirectory`입니다.

**2. 저장에 실패한 파일도 업로드 목록에 담깁니다.**

```java
try (FileOutputStream out = new FileOutputStream(propFile)) {
    prop.store(out, "messages");
} catch (IOException e) {
    log.error("Messages FileOutputStream IOException", e);
}

// files
files.add(propFile);
```

`files.add`가 catch 밖에 있어 저장 성공 여부와 무관하게 실행됩니다. 뒤에서 이 목록을 `storageUtils.storeFiles(files, "messages")`로 넘기므로, 존재하지 않는 파일이 FTP 전송 대상이 됩니다. 1번 결함이 발생한 상황에서는 세 개 전부가 그렇습니다.

## 변경 내용

- `Files.createDirectory`를 `Files.createDirectories`로 바꿔 부모 경로까지 만듭니다. 경로가 폴더가 아닌 일반 파일로 선점된 경우는 여전히 `FileAlreadyExistsException`으로 걸리므로 기존 catch는 그대로 뒀습니다.
- `files.add(propFile)`을 try 블록 안 `prop.store` 다음으로 옮겨 저장에 성공한 파일만 업로드 대상에 담습니다.
- 테스트 3건을 추가했습니다. Spring 컨텍스트 없이 저장소와 스토리지를 대역으로 두고 `@TempDir`에 파일을 만듭니다.

## 테스트 방법

```
cd backend/portal-service && ./gradlew test --tests 'org.egovframe.cloud.portalservice.config.MessageSourceFilesTest'
```

신규 3건이 모두 통과합니다.

- `file.directory`가 없는 상태에서 하위 `messages` 폴더까지 만들고 세 파일을 저장하는지, `messages_en.properties`에 영문명이 들어갔는지
- `messages` 자리를 일반 파일이 선점해 저장이 모두 실패하면 `storeFiles`를 호출하지 않는지
- 업로드 목록에 담긴 파일이 실제로 존재하는지

본문 수정만 되돌리고 테스트만 적용하면 3건 모두 실패합니다.

모듈 전체 테스트는 이 브랜치에서 118건 중 97건이 실패합니다. 다만 같은 명령을 main에서 실행해도 115건 중 97건이 실패합니다. 기존 실패는 DB 등 외부 의존이 필요한 테스트들이며 이번 변경과 무관합니다. 이번 변경으로 늘어난 3건은 모두 통과해 실패 건수는 그대로입니다.

## 영향 범위

- 수정 파일은 `MessageSourceFiles.java`(본문 3줄)와 신규 테스트 1개입니다.
- ftp 비활성 환경은 `FileStorageUtils`가 `file.directory`를 이미 만들어 두므로 동작이 달라지지 않습니다.
- 설정 키, 공개 API, 의존성 변경은 없습니다.
