### PR TITLE
test: 프론트엔드 공통 유틸 단위 테스트 추가 (portal·admin)

### DIFF
--- a/frontend/admin/src/utils/__tests__/utils.test.ts
+++ b/frontend/admin/src/utils/__tests__/utils.test.ts
@@ -1,0 +1,74 @@
+import { format, formatBytes, getType, Page, rownum, translateToLang } from '../index'
+
+const page = (overrides: Partial<Page> = {}): Page =>
+  ({
+    size: 10,
+    number: 0,
+    totalElements: 35,
+    ...overrides,
+  } as Page)
+
+describe('rownum', () => {
+  it('오름차순은 페이지 시작 번호에 행 순서를 더한다', () => {
+    expect(rownum(page(), 0, 'asc')).toBe(1)
+    expect(rownum(page({ number: 2 }), 3, 'asc')).toBe(24)
+  })
+
+  it('기본값은 내림차순이며 전체 건수에서 역순으로 매긴다', () => {
+    expect(rownum(page(), 0)).toBe(35)
+    expect(rownum(page(), 9)).toBe(26)
+    expect(rownum(page({ number: 3 }), 4)).toBe(1)
+  })
+})
+
+describe('formatBytes', () => {
+  it('1024 단위로 올려 표기한다', () => {
+    expect(formatBytes(0)).toBe('0 Bytes')
+    expect(formatBytes(512)).toBe('512 Bytes')
+    expect(formatBytes(1024)).toBe('1 KB')
+    expect(formatBytes(1536)).toBe('1.5 KB')
+    expect(formatBytes(1048576)).toBe('1 MB')
+  })
+
+  it('소수 자릿수를 지정할 수 있고 음수는 0자리로 처리한다', () => {
+    expect(formatBytes(1536, 0)).toBe('2 KB')
+    expect(formatBytes(1590, -1)).toBe('2 KB')
+  })
+})
+
+describe('format', () => {
+  it('{n} 자리를 인자로 치환한다', () => {
+    expect(format('{0}자 이내로 입력하세요', [20])).toBe('20자 이내로 입력하세요')
+    expect(format('{0} ~ {1}', ['가', '나'])).toBe('가 ~ 나')
+  })
+
+  it('대응하는 인자가 없으면 원래 표기를 남긴다', () => {
+    expect(format('{0} {1}', ['가'])).toBe('가 {1}')
+  })
+})
+
+describe('getType', () => {
+  it('값의 실제 타입 이름을 반환한다', () => {
+    expect(getType([])).toBe('Array')
+    expect(getType({})).toBe('Object')
+    expect(getType('a')).toBe('String')
+    expect(getType(1)).toBe('Number')
+    expect(getType(null)).toBe('Null')
+    expect(getType(undefined)).toBe('Undefined')
+  })
+})
+
+describe('translateToLang', () => {
+  const data = { korName: '한글명', engName: 'English' }
+
+  it('ko는 한글 키를, 그 외 언어는 영문 키를 반환한다', () => {
+    expect(translateToLang('ko', data)).toBe('한글명')
+    expect(translateToLang('en', data)).toBe('English')
+  })
+
+  it('키 이름을 직접 지정할 수 있다', () => {
+    const site = { siteKoName: '사이트', siteEnName: 'Site' }
+    expect(translateToLang('ko', site, 'siteKoName', 'siteEnName')).toBe('사이트')
+    expect(translateToLang('en', site, 'siteKoName', 'siteEnName')).toBe('Site')
+  })
+})

--- a/frontend/portal/src/utils/__tests__/utils.test.ts
+++ b/frontend/portal/src/utils/__tests__/utils.test.ts
@@ -1,0 +1,110 @@
+import {
+  format,
+  formatBytes,
+  getTextLength,
+  isValidPassword,
+  rownum,
+  translateToLang,
+} from '../index'
+import { Page } from '@service'
+
+const page = (overrides: Partial<Page> = {}): Page =>
+  ({
+    size: 10,
+    number: 0,
+    totalElements: 35,
+    ...overrides,
+  } as Page)
+
+describe('rownum', () => {
+  it('오름차순은 페이지 시작 번호에 행 순서를 더한다', () => {
+    expect(rownum(page(), 0, 'asc')).toBe(1)
+    expect(rownum(page({ number: 2 }), 3, 'asc')).toBe(24)
+  })
+
+  it('기본값은 내림차순이며 전체 건수에서 역순으로 매긴다', () => {
+    expect(rownum(page(), 0)).toBe(35)
+    expect(rownum(page(), 9)).toBe(26)
+    expect(rownum(page({ number: 3 }), 4)).toBe(1)
+  })
+})
+
+describe('formatBytes', () => {
+  it('1024 단위로 올려 표기한다', () => {
+    expect(formatBytes(0)).toBe('0 Bytes')
+    expect(formatBytes(512)).toBe('512 Bytes')
+    expect(formatBytes(1024)).toBe('1 KB')
+    expect(formatBytes(1536)).toBe('1.5 KB')
+    expect(formatBytes(1048576)).toBe('1 MB')
+    expect(formatBytes(1073741824)).toBe('1 GB')
+  })
+
+  it('소수 자릿수를 지정할 수 있고 음수는 0자리로 처리한다', () => {
+    expect(formatBytes(1536, 0)).toBe('2 KB')
+    expect(formatBytes(1536, 3)).toBe('1.5 KB')
+    expect(formatBytes(1590, -1)).toBe('2 KB')
+  })
+})
+
+describe('getTextLength', () => {
+  it('byte 모드는 한글을 2로 센다', () => {
+    expect(getTextLength('abc')).toBe(3)
+    expect(getTextLength('한글')).toBe(4)
+    expect(getTextLength('a한b')).toBe(4)
+  })
+
+  it('char 모드는 문자 수만 센다', () => {
+    expect(getTextLength('한글', 'char')).toBe(2)
+    expect(getTextLength('a한b', 'char')).toBe(3)
+  })
+
+  it('빈 문자열은 0이다', () => {
+    expect(getTextLength('')).toBe(0)
+    expect(getTextLength('', 'char')).toBe(0)
+  })
+})
+
+describe('format', () => {
+  it('{n} 자리를 인자로 치환한다', () => {
+    expect(format('{0}자 이내로 입력하세요', [20])).toBe('20자 이내로 입력하세요')
+    expect(format('{0} ~ {1}', ['가', '나'])).toBe('가 ~ 나')
+  })
+
+  it('같은 자리를 여러 번 써도 모두 치환한다', () => {
+    expect(format('{0}/{0}', ['x'])).toBe('x/x')
+  })
+
+  it('대응하는 인자가 없으면 원래 표기를 남긴다', () => {
+    expect(format('{0} {1}', ['가'])).toBe('가 {1}')
+    expect(format('{0}', [])).toBe('{0}')
+  })
+})
+
+describe('translateToLang', () => {
+  const data = { korName: '한글명', engName: 'English' }
+
+  it('ko는 한글 키를, 그 외 언어는 영문 키를 반환한다', () => {
+    expect(translateToLang('ko', data)).toBe('한글명')
+    expect(translateToLang('en', data)).toBe('English')
+  })
+
+  it('키 이름을 직접 지정할 수 있다', () => {
+    const site = { siteKoName: '사이트', siteEnName: 'Site' }
+    expect(translateToLang('ko', site, 'siteKoName', 'siteEnName')).toBe('사이트')
+    expect(translateToLang('en', site, 'siteKoName', 'siteEnName')).toBe('Site')
+  })
+})
+
+describe('isValidPassword', () => {
+  it('영문·숫자·특수문자를 모두 포함한 8~20자를 허용한다', () => {
+    expect(isValidPassword('abcd1234!')).toBe(true)
+    expect(isValidPassword('Ab1!Ab1!')).toBe(true)
+  })
+
+  it('구성 요소가 빠지거나 길이를 벗어나면 거부한다', () => {
+    expect(isValidPassword('abcdefgh')).toBe(false)
+    expect(isValidPassword('abcd1234')).toBe(false)
+    expect(isValidPassword('ab1!')).toBe(false)
+    expect(isValidPassword('a1!' + 'b'.repeat(18))).toBe(false)
+  })
+})


### PR DESCRIPTION
## 변경 이유

프론트엔드 소스는 portal·admin 합쳐 331개인데 테스트가 있는 파일은 2개입니다. 특히 `admin`에는 테스트가 하나도 없습니다. jest 설정(`jest.config.js`·`jest.setup.ts`)과 `npm test` 스크립트는 두 앱 모두 갖춰져 있어 실행 환경은 이미 준비된 상태입니다.

두 앱의 `src/utils/index.ts`는 목록·업로드·다국어 화면이 공통으로 쓰는 순수 함수 묶음입니다. 외부 의존이 없어 테스트 비용이 낮은데도 비어 있어 이번에 채웠습니다.

## 변경 내용

프로덕션 코드는 건드리지 않았고 테스트 파일 2개만 추가했습니다. 현재 동작을 그대로 고정하는 것이 목적이며, 동작을 바꾸는 수정은 넣지 않았습니다.

- `frontend/portal/src/utils/__tests__/utils.test.ts` — `rownum`, `formatBytes`, `getTextLength`, `format`, `translateToLang`, `isValidPassword`
- `frontend/admin/src/utils/__tests__/utils.test.ts` — `rownum`, `formatBytes`, `format`, `getType`, `translateToLang`

검증 항목은 다음과 같습니다.

- `rownum` — 오름차순은 페이지 시작 번호에 행 순서를 더하고, 기본값인 내림차순은 전체 건수에서 역순으로 매기는지
- `formatBytes` — 1024 단위 표기, 소수 자릿수 지정, 음수 자릿수를 0으로 처리하는지
- `getTextLength` — byte 모드에서 한글을 2로, char 모드에서 1로 세는지
- `format` — `{n}` 치환, 같은 자리 반복 치환, 인자가 없으면 원래 표기를 남기는지
- `translateToLang` — 언어별 필드 선택과 키 이름 직접 지정
- `isValidPassword` — 영문·숫자·특수문자를 모두 포함한 8~20자 허용, 요소 누락·길이 초과 거부
- `getType` — `Array`·`Object`·`String`·`Number`·`Null`·`Undefined` 판별

## 테스트 방법

```
cd frontend/portal && npm test
cd frontend/admin && npm test
```

portal은 21건에서 35건으로, admin은 0건에서 9건으로 늘었고 모두 통과합니다.

## 영향 범위

- 추가 파일은 테스트 2개(184줄)뿐입니다. 프로덕션 코드, 설정, 의존성 변경은 없습니다.
- 별건으로, `frontend/admin/jest.config.js`의 `moduleNameMapper`가 `<rootDir>/test/mocks.ts`를 가리키는데 실제 파일명은 `test/mock.ts`입니다. 이번에 추가한 테스트는 이미지·스타일을 import하지 않아 영향을 받지 않지만, 컴포넌트 테스트를 추가하면 모듈 해석에 실패합니다. 이 PR 범위와 달라 포함하지 않았고 필요하시면 따로 올리겠습니다.
