### PR TITLE
fix: 예약 검증기가 인스턴스 필드로 판정 결과를 공유해 동시 요청 시 섞이는 문제 수정

### DIFF
--- a/backend/reserve-check-service/src/main/java/org/egovframe/cloud/reservechecksevice/validator/ReserveSaveValidator.java
+++ b/backend/reserve-check-service/src/main/java/org/egovframe/cloud/reservechecksevice/validator/ReserveSaveValidator.java
@@ -41,7 +41,6 @@ public class ReserveSaveValidator implements ConstraintValidator<ReserveSaveVali
     protected MessageUtil messageUtil;
 
     private String message;
-    private boolean fieldValid;
 
 
     @Override
@@ -59,8 +58,6 @@ public class ReserveSaveValidator implements ConstraintValidator<ReserveSaveVali
     @SneakyThrows
     @Override
     public boolean isValid(Object value, ConstraintValidatorContext context) {
-        fieldValid = true;
-
         String categoryId = String.valueOf(getFieldValue(value, "categoryId"));
         if ("education".equals(categoryId)) {
             //교육인 경우
@@ -71,10 +68,8 @@ public class ReserveSaveValidator implements ConstraintValidator<ReserveSaveVali
         if ("equipment".equals(categoryId)) {
             //장비인 경우
             //신청일자(기간), 신청수량
-            fieldValid = checkReserveDate(value, context);
-            fieldValid = checkReserveQty(value, context);
-
-            return fieldValid;
+            // 두 검사를 모두 수행해 위반 사유를 함께 담는다
+            return checkReserveDate(value, context) & checkReserveQty(value, context);
         }
 
         if ("place".equals(categoryId)) {
@@ -83,7 +78,7 @@ public class ReserveSaveValidator implements ConstraintValidator<ReserveSaveVali
             return checkReserveDate(value, context);
         }
 
-        return fieldValid;
+        return true;
     }
 
     /**
@@ -105,7 +100,7 @@ public class ReserveSaveValidator implements ConstraintValidator<ReserveSaveVali
                 .addConstraintViolation();
             return false;
         }
-        return fieldValid;
+        return true;
     }
 
     /**
@@ -155,7 +150,7 @@ public class ReserveSaveValidator implements ConstraintValidator<ReserveSaveVali
             return false;
         }
 
-        return fieldValid;
+        return true;
     }
 
     /**

--- a/backend/reserve-check-service/src/test/java/org/egovframe/cloud/reservechecksevice/validator/ReserveSaveValidatorConcurrencyTest.java
+++ b/backend/reserve-check-service/src/test/java/org/egovframe/cloud/reservechecksevice/validator/ReserveSaveValidatorConcurrencyTest.java
@@ -1,0 +1,118 @@
+package org.egovframe.cloud.reservechecksevice.validator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Answers.RETURNS_DEEP_STUBS;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.egovframe.cloud.common.util.MessageUtil;
+import org.egovframe.cloud.reservechecksevice.api.dto.ReserveSaveRequestDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import jakarta.validation.ConstraintValidatorContext;
+
+/**
+ * {@link ReserveSaveValidator}가 여러 요청에서 동시에 호출돼도 판정 결과를 서로 침범하지 않는지 검증한다.
+ */
+class ReserveSaveValidatorConcurrencyTest {
+
+    private static final int THREADS = 16;
+    private static final int ROUNDS = 300;
+
+    private ReserveSaveValidator validator;
+
+    @BeforeEach
+    void setUp() {
+        validator = new ReserveSaveValidator();
+        MessageUtil messageUtil = mock(MessageUtil.class);
+        when(messageUtil.getMessage(anyString())).thenReturn("message");
+        when(messageUtil.getMessage(anyString(), any(Object[].class))).thenReturn("message");
+        ReflectionTestUtils.setField(validator, "messageUtil", messageUtil);
+    }
+
+    /** 예약 시작일이 종료일보다 늦어 반드시 거부돼야 하는 요청. */
+    private ReserveSaveRequestDto invalidDto() {
+        return ReserveSaveRequestDto.builder()
+                .categoryId("equipment")
+                .reserveQty(1)
+                .reserveStartDate(LocalDateTime.of(2026, 3, 2, 0, 0))
+                .reserveEndDate(LocalDateTime.of(2026, 3, 1, 0, 0))
+                .build();
+    }
+
+    /** 모든 조건을 만족해 통과해야 하는 요청. */
+    private ReserveSaveRequestDto validDto() {
+        return ReserveSaveRequestDto.builder()
+                .categoryId("equipment")
+                .reserveQty(1)
+                .reserveStartDate(LocalDateTime.of(2026, 3, 1, 0, 0))
+                .reserveEndDate(LocalDateTime.of(2026, 3, 2, 0, 0))
+                .build();
+    }
+
+    @Test
+    @DisplayName("한 인스턴스를 동시에 호출해도 잘못된 요청이 통과하지 않는다")
+    void concurrentValidationDoesNotLeakVerdicts() throws Exception {
+        ExecutorService pool = Executors.newFixedThreadPool(THREADS);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(THREADS);
+        AtomicInteger invalidAcceptedCount = new AtomicInteger();
+        AtomicInteger validRejectedCount = new AtomicInteger();
+
+        for (int t = 0; t < THREADS; t++) {
+            final boolean useInvalid = t % 2 == 0;
+            pool.execute(() -> {
+                try {
+                    start.await();
+                    for (int i = 0; i < ROUNDS; i++) {
+                        ConstraintValidatorContext context = mock(ConstraintValidatorContext.class, RETURNS_DEEP_STUBS);
+                        boolean result = validator.isValid(useInvalid ? invalidDto() : validDto(), context);
+                        if (useInvalid && result) {
+                            invalidAcceptedCount.incrementAndGet();
+                        }
+                        if (!useInvalid && !result) {
+                            validRejectedCount.incrementAndGet();
+                        }
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    done.countDown();
+                }
+            });
+        }
+
+        start.countDown();
+        assertThat(done.await(60, TimeUnit.SECONDS)).isTrue();
+        pool.shutdownNow();
+
+        assertThat(invalidAcceptedCount.get())
+                .as("예약 기간이 뒤집힌 요청이 통과한 횟수")
+                .isZero();
+        assertThat(validRejectedCount.get())
+                .as("정상 요청이 거부된 횟수")
+                .isZero();
+    }
+
+    @Test
+    @DisplayName("단일 스레드에서는 요청별 판정이 그대로 유지된다")
+    void singleThreadedValidationKeepsVerdicts() {
+        ConstraintValidatorContext context = mock(ConstraintValidatorContext.class, RETURNS_DEEP_STUBS);
+
+        assertThat(validator.isValid(invalidDto(), context)).isFalse();
+        assertThat(validator.isValid(validDto(), context)).isTrue();
+        assertThat(validator.isValid(invalidDto(), context)).isFalse();
+    }
+}

--- a/backend/reserve-item-service/src/main/java/org/egovframe/cloud/reserveitemservice/validator/ReserveItemSaveValidator.java
+++ b/backend/reserve-item-service/src/main/java/org/egovframe/cloud/reserveitemservice/validator/ReserveItemSaveValidator.java
@@ -39,7 +39,6 @@ public class ReserveItemSaveValidator implements ConstraintValidator<ReserveItem
     protected MessageUtil messageUtil;
 
     private String message;
-    private boolean fieldValid;
 
     @Override
     public void initialize(ReserveItemSaveValid constraintAnnotation) {
@@ -56,26 +55,24 @@ public class ReserveItemSaveValidator implements ConstraintValidator<ReserveItem
     @SneakyThrows
     @Override
     public boolean isValid(Object value, ConstraintValidatorContext context) {
-        fieldValid = true;
-
         // 운영 시작일, 종료일 체크
-        validateOperationDate(value, context);
+        boolean fieldValid = validateOperationDate(value, context);
 
         // 유료인 경우 이용 요금 필수
-        validatePaid(value, context);
+        fieldValid &= validatePaid(value, context);
 
         String reserveMethodId = String.valueOf(getFieldValue(value, "reserveMethodId"));
         //예약 방법이 '인터넷' 인경우
         if ("internet".equals(reserveMethodId)) {
-            return validateInternet(value, context);
+            return validateInternet(value, context) & fieldValid;
         }
 
         if ("phone".equals(reserveMethodId)) {
-            return validateTelephone(value, context);
+            return validateTelephone(value, context) & fieldValid;
         }
 
         if ("visit".equals(reserveMethodId)) {
-            return validateVisit(value, context);
+            return validateVisit(value, context) & fieldValid;
         }
 
         return fieldValid;
@@ -90,7 +87,7 @@ public class ReserveItemSaveValidator implements ConstraintValidator<ReserveItem
      * @throws NoSuchFieldException
      * @throws IllegalAccessException
      */
-    private void validateOperationDate(Object value, ConstraintValidatorContext context)
+    private boolean validateOperationDate(Object value, ConstraintValidatorContext context)
         throws NoSuchFieldException, IllegalAccessException {
         LocalDateTime operationStartDate = (LocalDateTime) getFieldValue(value,
             "operationStartDate");
@@ -105,8 +102,10 @@ public class ReserveItemSaveValidator implements ConstraintValidator<ReserveItem
                         messageUtil.getMessage("common.end_date")}))
                 .addPropertyNode("operationStartDate")
                 .addConstraintViolation();
-            fieldValid = false;
+            return false;
         }
+
+        return true;
     }
 
     /**
@@ -118,7 +117,7 @@ public class ReserveItemSaveValidator implements ConstraintValidator<ReserveItem
      * @throws NoSuchFieldException
      * @throws IllegalAccessException
      */
-    private void validatePaid(Object value, ConstraintValidatorContext context)
+    private boolean validatePaid(Object value, ConstraintValidatorContext context)
         throws NoSuchFieldException, IllegalAccessException {
         Boolean isPaid = Boolean.valueOf(String.valueOf(getFieldValue(value, "isPaid")));
         if (isPaid && isNull(value, "usageCost")) {
@@ -129,8 +128,10 @@ public class ReserveItemSaveValidator implements ConstraintValidator<ReserveItem
                     .getMessage("valid.required"))
                 .addPropertyNode("usageCost")
                 .addConstraintViolation();
-            fieldValid = false;
+            return false;
         }
+
+        return true;
     }
 
     /**
@@ -154,7 +155,7 @@ public class ReserveItemSaveValidator implements ConstraintValidator<ReserveItem
             return false;
         }
 
-        return fieldValid;
+        return true;
     }
 
     /**
@@ -178,7 +179,7 @@ public class ReserveItemSaveValidator implements ConstraintValidator<ReserveItem
                 .addConstraintViolation();
             return false;
         }
-        return fieldValid;
+        return true;
     }
 
     /**
@@ -224,7 +225,7 @@ public class ReserveItemSaveValidator implements ConstraintValidator<ReserveItem
             }
         }
 
-        return fieldValid;
+        return true;
     }
 
     /**
@@ -238,13 +239,8 @@ public class ReserveItemSaveValidator implements ConstraintValidator<ReserveItem
      */
     private boolean validateRealTime(Object value, ConstraintValidatorContext context)
         throws NoSuchFieldException, IllegalAccessException {
-        // 예약 신청 기간 필수
-        fieldValid = validateRequestDate(value, context);
-
-        //기간 지정 필수
-        fieldValid = validatePeriod(value, context);
-
-        return fieldValid;
+        // 예약 신청 기간 필수, 기간 지정 필수 — 두 검사를 모두 수행해 위반 사유를 함께 담는다
+        return validateRequestDate(value, context) & validatePeriod(value, context);
     }
 
     /**
@@ -281,7 +277,7 @@ public class ReserveItemSaveValidator implements ConstraintValidator<ReserveItem
             return false;
         }
 
-        return fieldValid;
+        return true;
     }
 
     /**
@@ -332,7 +328,7 @@ public class ReserveItemSaveValidator implements ConstraintValidator<ReserveItem
             return false;
         }
 
-        return fieldValid;
+        return true;
     }
 
     /**

--- a/backend/reserve-item-service/src/test/java/org/egovframe/cloud/reserveitemservice/validator/ReserveItemSaveValidatorConcurrencyTest.java
+++ b/backend/reserve-item-service/src/test/java/org/egovframe/cloud/reserveitemservice/validator/ReserveItemSaveValidatorConcurrencyTest.java
@@ -1,0 +1,131 @@
+package org.egovframe.cloud.reserveitemservice.validator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Answers.RETURNS_DEEP_STUBS;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.egovframe.cloud.common.util.MessageUtil;
+import org.egovframe.cloud.reserveitemservice.api.reserveItem.dto.ReserveItemSaveRequestDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import jakarta.validation.ConstraintValidatorContext;
+
+/**
+ * {@link ReserveItemSaveValidator}가 여러 요청에서 동시에 호출돼도 판정 결과를 서로 침범하지 않는지 검증한다.
+ *
+ * <p>Bean Validation 구현체는 ConstraintValidator 인스턴스를 캐시해 재사용하므로 한 인스턴스가 여러 스레드에서
+ * 동시에 쓰인다.
+ */
+class ReserveItemSaveValidatorConcurrencyTest {
+
+    private static final int THREADS = 16;
+    private static final int ROUNDS = 300;
+
+    private ReserveItemSaveValidator validator;
+
+    @BeforeEach
+    void setUp() {
+        validator = new ReserveItemSaveValidator();
+        MessageUtil messageUtil = mock(MessageUtil.class);
+        when(messageUtil.getMessage(anyString())).thenReturn("message");
+        when(messageUtil.getMessage(anyString(), any(Object[].class))).thenReturn("message");
+        ReflectionTestUtils.setField(validator, "messageUtil", messageUtil);
+    }
+
+    /** 운영 시작일이 종료일보다 늦어 반드시 거부돼야 하는 요청. */
+    private ReserveItemSaveRequestDto invalidDto() {
+        return ReserveItemSaveRequestDto.builder()
+                .reserveItemName("회의실")
+                .operationStartDate(LocalDateTime.of(2026, 3, 2, 0, 0))
+                .operationEndDate(LocalDateTime.of(2026, 3, 1, 0, 0))
+                .reserveMethodId("visit")
+                .address("서울")
+                .isPaid(false)
+                .isUse(true)
+                .build();
+    }
+
+    /** 모든 조건을 만족해 통과해야 하는 요청. */
+    private ReserveItemSaveRequestDto validDto() {
+        return ReserveItemSaveRequestDto.builder()
+                .reserveItemName("회의실")
+                .operationStartDate(LocalDateTime.of(2026, 3, 1, 0, 0))
+                .operationEndDate(LocalDateTime.of(2026, 3, 2, 0, 0))
+                .reserveMethodId("visit")
+                .address("서울")
+                .isPaid(false)
+                .isUse(true)
+                .build();
+    }
+
+    @Test
+    @DisplayName("한 인스턴스를 동시에 호출해도 잘못된 요청이 통과하지 않는다")
+    void concurrentValidationDoesNotLeakVerdicts() throws Exception {
+        ExecutorService pool = Executors.newFixedThreadPool(THREADS);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(THREADS);
+        AtomicInteger invalidAcceptedCount = new AtomicInteger();
+        AtomicInteger validRejectedCount = new AtomicInteger();
+        List<Runnable> tasks = new ArrayList<>();
+
+        for (int t = 0; t < THREADS; t++) {
+            final boolean useInvalid = t % 2 == 0;
+            tasks.add(() -> {
+                try {
+                    start.await();
+                    for (int i = 0; i < ROUNDS; i++) {
+                        ConstraintValidatorContext context = mock(ConstraintValidatorContext.class, RETURNS_DEEP_STUBS);
+                        boolean result = validator.isValid(useInvalid ? invalidDto() : validDto(), context);
+                        if (useInvalid && result) {
+                            invalidAcceptedCount.incrementAndGet();
+                        }
+                        if (!useInvalid && !result) {
+                            validRejectedCount.incrementAndGet();
+                        }
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    done.countDown();
+                }
+            });
+        }
+
+        tasks.forEach(pool::execute);
+        start.countDown();
+        assertThat(done.await(60, TimeUnit.SECONDS)).isTrue();
+        pool.shutdownNow();
+
+        assertThat(invalidAcceptedCount.get())
+                .as("운영 기간이 뒤집힌 요청이 통과한 횟수")
+                .isZero();
+        assertThat(validRejectedCount.get())
+                .as("정상 요청이 거부된 횟수")
+                .isZero();
+    }
+
+    @Test
+    @DisplayName("단일 스레드에서는 요청별 판정이 그대로 유지된다")
+    void singleThreadedValidationKeepsVerdicts() {
+        ConstraintValidatorContext context = mock(ConstraintValidatorContext.class, RETURNS_DEEP_STUBS);
+
+        assertThat(validator.isValid(invalidDto(), context)).isFalse();
+        assertThat(validator.isValid(validDto(), context)).isTrue();
+        assertThat(validator.isValid(invalidDto(), context)).isFalse();
+    }
+}


### PR DESCRIPTION
## 변경 이유

`ReserveItemSaveValidator`(예약 물품 저장)와 `ReserveSaveValidator`(예약 신청)가 검사 결과를 인스턴스 필드에 담습니다.

```java
private String message;
private boolean fieldValid;

@Override
public boolean isValid(Object value, ConstraintValidatorContext context) {
    fieldValid = true;
    ...
    fieldValid = false;   // 위반 발견 시
    ...
    return fieldValid;
}
```

Bean Validation 구현체는 `ConstraintValidator` 인스턴스를 제약조건별로 캐시해 재사용합니다. 즉 이 한 인스턴스를 모든 요청이 공유합니다. 명세도 구현체가 스레드 안전할 것을 전제합니다.

`isValid` 진입 시 `fieldValid`를 `true`로 되돌리므로, 요청 A가 위반을 기록한 뒤 반환하기 전에 요청 B가 진입하면 A의 기록이 지워집니다. A는 위반이 있는데도 `true`를 반환합니다. **잘못된 요청이 검증을 통과합니다.** 두 서비스 모두 WebFlux 기반이라 이벤트 루프 스레드에서 동시 검증이 일상적으로 일어납니다.

`initialize`에서 한 번만 쓰고 읽지 않는 `message` 필드는 문제가 되지 않습니다. 요청마다 바뀌는 값은 `fieldValid` 하나입니다.

## 재현

한 인스턴스를 16개 스레드가 공유하고, 절반은 기간이 뒤집힌 요청(운영/예약 시작일 > 종료일)을, 절반은 정상 요청을 300회씩 검증하도록 했습니다. 수정 전 기준입니다.

| 검증기 | 전체 잘못된 요청 | 통과해 버린 횟수 |
|---|---|---|
| `ReserveItemSaveValidator` | 2,400 | 169 |
| `ReserveSaveValidator` | 2,400 | 84 |

정상 요청이 거부된 경우는 없었습니다. 한 방향으로만, 즉 거부돼야 할 요청이 통과하는 쪽으로만 어긋납니다.

## 변경 내용

- `fieldValid` 인스턴스 필드를 제거하고 판정 결과를 지역 변수로 옮겼습니다.
- 결과를 필드에 적고 마지막에 `return fieldValid` 하던 검사 메서드들이 각자 자기 결과를 반환하도록 고쳤습니다. `validateOperationDate`·`validatePaid`는 반환 타입을 `void`에서 `boolean`으로 바꿨습니다.
- 여러 검사를 잇달아 수행하던 자리(`validateRealTime`, 장비 예약 분기)는 비단축 평가 `&`로 묶었습니다. 앞 검사가 실패해도 뒤 검사를 수행해 위반 사유를 모두 담던 기존 동작을 유지하기 위해서입니다.
- 두 서비스에 동시성 테스트를 각각 추가했습니다. 위 재현 조건을 그대로 고정하고, 단일 스레드에서 요청별 판정이 유지되는지도 함께 확인합니다.

판정 규칙 자체는 바꾸지 않았습니다. 어떤 입력을 거부할지는 수정 전후가 같습니다.

## 테스트 방법

```
cd backend/reserve-item-service && ./gradlew test --tests '*ReserveItemSaveValidatorConcurrencyTest'
cd backend/reserve-check-service && ./gradlew test --tests '*ReserveSaveValidatorConcurrencyTest'
```

신규 4건이 모두 통과합니다. 본문 수정만 되돌리면 두 서비스의 동시성 테스트가 각각 실패하고, 위 표의 수치가 나옵니다.

모듈 전체 테스트는 main에서도 실패하는 항목이 있어 함께 적습니다. 기존 실패는 외부 의존이 필요한 테스트들이며 이번 변경과 무관합니다. 실패 건수는 그대로이고 통과 건수만 늘었습니다.

| 모듈 | main | 이 브랜치 |
|---|---|---|
| reserve-item-service | 35건 중 16건 실패 | 37건 중 16건 실패 |
| reserve-check-service | 39건 중 18건 실패 | 41건 중 18건 실패 |

## 영향 범위

- 수정 파일은 검증기 2개(본문 각 15줄·44줄)와 신규 테스트 2개입니다.
- 공개 API, 설정, 의존성 변경은 없습니다. 검증 실패 시 반환되는 메시지와 대상 필드도 그대로입니다.
