### PR TITLE
fix: 테스트가 메인 설정 파일을 로드하지 못해 컨텍스트 기동이 실패하는 문제 수정

### DIFF
--- a/backend/board-service/src/test/java/org/egovframe/cloud/boardservice/api/board/BoardApiControllerTest.java
+++ b/backend/board-service/src/test/java/org/egovframe/cloud/boardservice/api/board/BoardApiControllerTest.java
@@ -20,7 +20,6 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 
 import java.math.BigDecimal;
 import java.util.*;
@@ -47,7 +46,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Slf4j
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @EnableConfigurationProperties
-@TestPropertySource(properties = {"spring.config.location=classpath:application-test.yml"})
 @ActiveProfiles(profiles = "test")
 public class BoardApiControllerTest {
 

--- a/backend/board-service/src/test/java/org/egovframe/cloud/boardservice/api/comment/CommentApiControllerTest.java
+++ b/backend/board-service/src/test/java/org/egovframe/cloud/boardservice/api/comment/CommentApiControllerTest.java
@@ -32,7 +32,6 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -56,7 +55,6 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @EnableConfigurationProperties
-@TestPropertySource(properties = {"spring.config.location=classpath:application-test.yml"})
 @ActiveProfiles(profiles = "test")
 class CommentApiControllerTest {
 

--- a/backend/board-service/src/test/java/org/egovframe/cloud/boardservice/api/posts/PostsApiControllerTest.java
+++ b/backend/board-service/src/test/java/org/egovframe/cloud/boardservice/api/posts/PostsApiControllerTest.java
@@ -38,7 +38,6 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -67,7 +66,6 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @EnableConfigurationProperties
-@TestPropertySource(properties = {"spring.config.location=classpath:application-test.yml"})
 @ActiveProfiles(profiles = "test")
 class PostsApiControllerTest {
 

--- a/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/api/attachment/AttachmentApiControllerTest.java
+++ b/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/api/attachment/AttachmentApiControllerTest.java
@@ -45,7 +45,6 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.multipart.MultipartFile;
@@ -53,7 +52,6 @@ import org.springframework.web.multipart.MultipartFile;
 @Slf4j
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @EnableConfigurationProperties
-@TestPropertySource(properties = {"spring.config.location=classpath:application-test.yml"})
 @ActiveProfiles(profiles = "test")
 class AttachmentApiControllerTest {
     @Autowired

--- a/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/api/banner/BannerApiControllerTest.java
+++ b/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/api/banner/BannerApiControllerTest.java
@@ -42,7 +42,6 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 
 /**
  * org.egovframe.cloud.portalservice.api.banner.BannerApiControllerTest
@@ -63,7 +62,6 @@ import org.springframework.test.context.TestPropertySource;
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @EnableConfigurationProperties
-@TestPropertySource(properties = {"spring.config.location=classpath:application-test.yml"})
 @ActiveProfiles(profiles = "test")
 class BannerApiControllerTest {
 

--- a/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/api/code/CodeApiControllerTest.java
+++ b/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/api/code/CodeApiControllerTest.java
@@ -23,7 +23,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -50,7 +49,6 @@ import lombok.extern.slf4j.Slf4j;
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @EnableConfigurationProperties
-@TestPropertySource(properties = {"spring.config.location=classpath:application-test.yml"})
 @ActiveProfiles(profiles = "test")
 class CodeApiControllerTest {
 

--- a/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/api/code/CodeDetailApiControllerTest.java
+++ b/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/api/code/CodeDetailApiControllerTest.java
@@ -26,7 +26,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -53,7 +52,6 @@ import lombok.extern.slf4j.Slf4j;
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @EnableConfigurationProperties
-@TestPropertySource(properties = {"spring.config.location=classpath:application-test.yml"})
 @ActiveProfiles(profiles = "test")
 class CodeDetailApiControllerTest {
 

--- a/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/api/content/ContentApiControllerTest.java
+++ b/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/api/content/ContentApiControllerTest.java
@@ -27,7 +27,6 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 
 /**
  * org.egovframe.cloud.portalservice.api.content.ContentApiControllerTest
@@ -48,7 +47,6 @@ import org.springframework.test.context.TestPropertySource;
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @EnableConfigurationProperties
-@TestPropertySource(properties = {"spring.config.location=classpath:application-test.yml"})
 @ActiveProfiles(profiles = "test")
 class ContentApiControllerTest {
 

--- a/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/api/menu/MenuApiControllerTest.java
+++ b/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/api/menu/MenuApiControllerTest.java
@@ -29,11 +29,9 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @EnableConfigurationProperties
-@TestPropertySource(properties = {"spring.config.location=classpath:application-test.yml"})
 @ActiveProfiles(profiles = "test")
 class MenuApiControllerTest {
 

--- a/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/api/menu/MenuRoleApiControllerTest.java
+++ b/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/api/menu/MenuRoleApiControllerTest.java
@@ -30,12 +30,10 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @EnableConfigurationProperties
-@TestPropertySource(properties = {"spring.config.location=classpath:application-test.yml"})
 @ActiveProfiles(profiles = "test")
 class MenuRoleApiControllerTest {
 

--- a/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/api/message/MessageApiControllerTest.java
+++ b/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/api/message/MessageApiControllerTest.java
@@ -19,11 +19,9 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @EnableConfigurationProperties
-@TestPropertySource(properties = {"spring.config.location=classpath:application-test.yml"})
 @ActiveProfiles(profiles = "test")
 class MessageApiControllerTest {
 

--- a/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/api/policy/PolicyApiControllerTest.java
+++ b/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/api/policy/PolicyApiControllerTest.java
@@ -27,13 +27,11 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @EnableConfigurationProperties
-@TestPropertySource(properties = {"spring.config.location=classpath:application-test.yml"})
 @ActiveProfiles(profiles = "test")
 class PolicyApiControllerTest {
 

--- a/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/api/privacy/PrivacyApiControllerTest.java
+++ b/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/api/privacy/PrivacyApiControllerTest.java
@@ -27,7 +27,6 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 
 /**
  * org.egovframe.cloud.portalservice.api.privacy.PrivacyApiControllerTest
@@ -48,7 +47,6 @@ import org.springframework.test.context.TestPropertySource;
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @EnableConfigurationProperties
-@TestPropertySource(properties = {"spring.config.location=classpath:application-test.yml"})
 @ActiveProfiles(profiles = "test")
 class PrivacyApiControllerTest {
 

--- a/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/api/statistics/StatisticsApiControllerTest.java
+++ b/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/api/statistics/StatisticsApiControllerTest.java
@@ -23,11 +23,9 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @EnableConfigurationProperties
-@TestPropertySource(properties = {"spring.config.location=classpath:application-test.yml"})
 @ActiveProfiles(profiles = "test")
 class StatisticsApiControllerTest {
 

--- a/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/config/ExceptionResponseTest.java
+++ b/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/config/ExceptionResponseTest.java
@@ -10,7 +10,6 @@ import org.springframework.context.MessageSource;
 import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
@@ -34,7 +33,6 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @EnableConfigurationProperties
-@TestPropertySource(properties = {"spring.config.location=classpath:application-test.yml"})
 @ActiveProfiles(profiles = "test")
 public class ExceptionResponseTest {
 

--- a/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/config/MessageSourceConfigTest.java
+++ b/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/config/MessageSourceConfigTest.java
@@ -8,11 +8,9 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @EnableConfigurationProperties
-@TestPropertySource(properties = {"spring.config.location=classpath:application-test.yml"})
 @ActiveProfiles(profiles = "test")
 class MessageSourceConfigTest {
 

--- a/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/config/MessageSourceTest.java
+++ b/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/config/MessageSourceTest.java
@@ -8,7 +8,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.MessageSource;
 import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 
 /**
  * org.egovframe.cloud.portalservice.config.MessageSourceTest
@@ -29,7 +28,6 @@ import org.springframework.test.context.TestPropertySource;
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @EnableConfigurationProperties
-@TestPropertySource(properties = {"spring.config.location=classpath:application-test.yml"})
 @ActiveProfiles(profiles = "test")
 public class MessageSourceTest {
 

--- a/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/domain/attachment/AttachmentRepositoryTest.java
+++ b/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/domain/attachment/AttachmentRepositoryTest.java
@@ -12,11 +12,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @EnableConfigurationProperties
-@TestPropertySource(properties = {"spring.config.location=classpath:application-test.yml"})
 @ActiveProfiles(profiles = "test")
 class AttachmentRepositoryTest {
     @Autowired

--- a/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/domain/code/CodeRepositoryTest.java
+++ b/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/domain/code/CodeRepositoryTest.java
@@ -12,7 +12,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.transaction.annotation.Transactional;
 
 import jakarta.persistence.EntityManager;
@@ -40,7 +39,6 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @EnableConfigurationProperties
-@TestPropertySource(properties = {"spring.config.location=classpath:application-test.yml"})
 @ActiveProfiles(profiles = "test")
 class CodeRepositoryTest {
 

--- a/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/domain/menu/MenuRepositoryTest.java
+++ b/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/domain/menu/MenuRepositoryTest.java
@@ -8,7 +8,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.transaction.annotation.Transactional;
 
 import jakarta.persistence.EntityManager;
@@ -20,7 +19,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @EnableConfigurationProperties
-@TestPropertySource(properties = {"spring.config.location=classpath:application-test.yml"})
 @ActiveProfiles(profiles = "test")
 class MenuRepositoryTest {
 

--- a/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/domain/menu/MenuRoleRepositoryTest.java
+++ b/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/domain/menu/MenuRoleRepositoryTest.java
@@ -10,7 +10,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.transaction.annotation.Transactional;
 
 import jakarta.persistence.EntityManager;
@@ -22,7 +21,6 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @EnableConfigurationProperties
-@TestPropertySource(properties = {"spring.config.location=classpath:application-test.yml"})
 @ActiveProfiles(profiles = "test")
 class MenuRoleRepositoryTest {
     @Autowired

--- a/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/domain/message/MessageRepositoryTest.java
+++ b/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/domain/message/MessageRepositoryTest.java
@@ -8,7 +8,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -19,7 +18,6 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @EnableConfigurationProperties
-@TestPropertySource(properties = {"spring.config.location=classpath:application-test.yml"})
 @ActiveProfiles(profiles = "test")
 class MessageRepositoryTest {
 

--- a/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/domain/policy/PolicyRepositoryTest.java
+++ b/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/domain/policy/PolicyRepositoryTest.java
@@ -12,7 +12,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,7 +24,6 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @EnableConfigurationProperties
-@TestPropertySource(properties = {"spring.config.location=classpath:application-test.yml"})
 @ActiveProfiles(profiles = "test")
 class PolicyRepositoryTest {
 

--- a/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/domain/statistics/StatisticsRepositoryTest.java
+++ b/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/domain/statistics/StatisticsRepositoryTest.java
@@ -9,13 +9,11 @@ import org.springframework.boot.test.context.SpringBootTest;
 import jakarta.persistence.EntityManager;
 import java.util.UUID;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @EnableConfigurationProperties
-@TestPropertySource(properties = {"spring.config.location=classpath:application-test.yml"})
 @ActiveProfiles(profiles = "test")
 class StatisticsRepositoryTest {
     @Autowired

--- a/backend/user-service/src/test/java/org/egovframe/cloud/userservice/api/role/AuthorizationApiControllerTest.java
+++ b/backend/user-service/src/test/java/org/egovframe/cloud/userservice/api/role/AuthorizationApiControllerTest.java
@@ -19,7 +19,6 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -54,7 +53,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @EnableConfigurationProperties
-@TestPropertySource(properties = {"spring.config.location=classpath:application-test.yml"})
 @ActiveProfiles(profiles = "test")
 class AuthorizationApiControllerTest {
 

--- a/backend/user-service/src/test/java/org/egovframe/cloud/userservice/api/role/RoleApiControllerTest.java
+++ b/backend/user-service/src/test/java/org/egovframe/cloud/userservice/api/role/RoleApiControllerTest.java
@@ -14,7 +14,6 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -45,7 +44,6 @@ import org.springframework.web.filter.CharacterEncodingFilter;
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @EnableConfigurationProperties
-@TestPropertySource(properties = {"spring.config.location=classpath:application-test.yml"})
 @ActiveProfiles(profiles = "test")
 class RoleApiControllerTest {
 

--- a/backend/user-service/src/test/java/org/egovframe/cloud/userservice/api/role/RoleAuthorizationApiControllerTest.java
+++ b/backend/user-service/src/test/java/org/egovframe/cloud/userservice/api/role/RoleAuthorizationApiControllerTest.java
@@ -29,7 +29,6 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -62,7 +61,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @EnableConfigurationProperties
-@TestPropertySource(properties = {"spring.config.location=classpath:application-test.yml"})
 @ActiveProfiles(profiles = "test")
 class RoleAuthorizationApiControllerTest {
 

--- a/backend/user-service/src/test/java/org/egovframe/cloud/userservice/api/user/UserApiControllerTest.java
+++ b/backend/user-service/src/test/java/org/egovframe/cloud/userservice/api/user/UserApiControllerTest.java
@@ -22,7 +22,6 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -42,7 +41,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @EnableConfigurationProperties
-@TestPropertySource(properties = {"spring.config.location=classpath:application-test.yml"})
 @ActiveProfiles(profiles = "test")
 class UserApiControllerTest {
 

--- a/backend/user-service/src/test/java/org/egovframe/cloud/userservice/config/MessageSourceConfigTest.java
+++ b/backend/user-service/src/test/java/org/egovframe/cloud/userservice/config/MessageSourceConfigTest.java
@@ -9,14 +9,12 @@ import org.springframework.context.MessageSource;
 
 import java.util.Locale;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @EnableConfigurationProperties
-@TestPropertySource(properties = {"spring.config.location=classpath:application-test.yml"})
 @ActiveProfiles(profiles = "test")
 class MessageSourceConfigTest {
 


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

`board-service`·`user-service`·`portal-service`의 테스트 29개 클래스가 `ApplicationContext` 기동 단계에서 실패해 테스트 메서드 본문이 실행되지 않고 있습니다. 세 서비스 테스트 203건 중 157건이 여기에 해당합니다.

원인은 해당 클래스들에 붙어 있는 다음 애노테이션입니다.

```java
@TestPropertySource(properties = {"spring.config.location=classpath:application-test.yml"})
```

`spring.config.location`은 설정 파일을 찾을 기본 위치를 **대체**하는 속성입니다. 이 값을 지정하면 기본 탐색 위치가 목록에서 빠지므로 `src/main/resources/application.yml`이 로드되지 않습니다. Spring Boot 레퍼런스 [Externalized Configuration](https://docs.spring.io/spring-boot/reference/features/external-config.html)에 다음과 같이 명시돼 있습니다.

> Locations configured by using `spring.config.location` replace the default locations.

같은 문서는 프로파일 파일이 기본 파일을 **대체하지 않고 그 위에 얹힌다**고 설명합니다.

> Profile-specific properties are loaded from the same locations as standard `application.properties`, with profile-specific files always overriding the non-specific ones.

즉 `application-test.yml`은 `application.yml`을 대체하는 파일이 아니라 그 위에 덮어쓰는 차이분입니다. 실제로 세 서비스의 `application-test.yml`에는 H2 접속 정보, JPA `ddl-auto`, OAuth2 더미 자격증명, Eureka 등록 해제 등 테스트에서 달라져야 하는 값만 들어 있고, 나머지는 `application.yml`에서 물려받는 것을 전제로 작성돼 있습니다.

그런데 r2dbc 자동설정을 제외하는 설정이 `application.yml`에만 있습니다. `user-service` 기준 26~30행입니다.

```yaml
  autoconfigure:
    exclude:
      - org.springframework.boot.autoconfigure.r2dbc.R2dbcAutoConfiguration
      - org.springframework.boot.autoconfigure.data.r2dbc.R2dbcDataAutoConfiguration
      - org.springframework.boot.autoconfigure.r2dbc.R2dbcTransactionManagerAutoConfiguration
```

이 세 줄이 적용되지 않으면 `R2dbcAutoConfiguration`이 활성화되어 `ConnectionFactory` 빈을 생성하려 하는데, 세 서비스에는 r2dbc URL 설정도 드라이버도 없어 실패합니다. 이어서 `entityManagerFactory`의 의존 초기화가 함께 실패하고 컨텍스트가 기동하지 못합니다.

```
Error creating bean with name 'entityManagerFactory' defined in class path resource
  [org/egovframe/cloud/boardservice/config/BoardServiceJpaConfig.class]:
Failed to initialize dependency 'r2dbcScriptDatabaseInitializer' of
  LoadTimeWeaverAware bean 'entityManagerFactory':
  Error creating bean with name 'r2dbcScriptDatabaseInitializer' ...
    Error creating bean with name 'connectionFactory' ...
      Factory method 'connectionFactory' threw exception with message:
      Failed to determine a suitable R2DBC Connection URL
```

r2dbc는 `org.egovframe.cloud:egovframe-cloud-module-common`이 `spring-boot-starter-data-r2dbc`를 `runtime` 스코프로 가져오면서 클래스패스에 들어옵니다. 세 서비스에 리액티브 코드는 없으므로 `application.yml`의 제외 설정이 원래 의도된 처리로 보입니다.

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

테스트 소스 29개 파일에서 해당 애노테이션과 그에 딸린 import 두 줄을 제거했습니다. `src/main` 아래는 한 줄도 수정하지 않았습니다.

```diff
--- a/backend/board-service/src/test/java/.../BoardApiControllerTest.java
+++ b/backend/board-service/src/test/java/.../BoardApiControllerTest.java
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;

 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @EnableConfigurationProperties
-@TestPropertySource(properties = {"spring.config.location=classpath:application-test.yml"})
 @ActiveProfiles(profiles = "test")
 public class BoardApiControllerTest {
```

제거해도 `application-test.yml`은 그대로 로드됩니다. 바로 아래 줄의 `@ActiveProfiles(profiles = "test")`가 `classpath:/application-test.yml`을 활성 프로파일 파일로 읽어들이기 때문입니다. 따라서 이 애노테이션은 같은 파일을 한 번 더 지정하면서 `application.yml`만 배제하는 결과가 됩니다.

대상 파일은 서비스별로 다음과 같습니다.

| 서비스 | 파일 수 | 위치 |
|---|---|---|
| `board-service` | 3 | `api/board`·`api/comment`·`api/posts` |
| `user-service` | 5 | `api/role` 3건, `api/user` 1건, `config/MessageSourceConfigTest` |
| `portal-service` | 21 | `api/` 11건, `config/` 3건, `domain/` 7건 |

`apigateway`와 예약 관련 서비스 3곳에도 같은 애노테이션을 가진 테스트가 5개 있습니다. 다만 이 서비스들은 r2dbc 드라이버를 직접 선언하고 있어 이 문제가 발현하지 않으므로 이번 수정 범위에 넣지 않았습니다. 실패하지 않는 파일까지 함께 변경하면 수정 사유가 흐려진다고 판단했습니다.

다른 방식도 검토했습니다. `application-test.yml`에 r2dbc 제외 설정을 복사하는 방식은 컨텍스트 기동 문제는 해소되지만, `application.yml`을 계속 읽지 못하는 상태가 유지됩니다. `user-service` 기준으로 `application.yml`에만 있는 설정 키가 20개 더 있고, `portal-service`에서는 업로드 크기 설정이 여기에 포함됩니다. 그 경우 테스트가 Spring Boot 기본값인 1MB로 동작하게 되어 첨부 관련 테스트의 전제가 달라집니다. 또 앞으로 `application.yml`에 무엇을 추가해도 테스트에는 반영되지 않습니다. 각 서비스 `build.gradle`에서 r2dbc 의존성을 제외하는 방식은 변경량이 가장 적지만 운영 의존성 그래프를 바꾸는 것이어서, 서비스를 실제로 기동해 검증할 수 없는 상태에서는 제안하기 어렵다고 보았습니다.

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

세 서비스 전체 테스트를 수정 전후로 각각 실행해 대조했습니다. JDK 17, Gradle Wrapper 8.5 기준이며 서비스별로 `./gradlew test`를 실행했습니다.

| 서비스 | 전체 | 수정 전 실패 | 수정 후 실패 | 수정 전 통과 | 수정 후 통과 | 수정 후 skipped |
|---|---|---|---|---|---|---|
| `board-service` | 34 | 27 | 27 | 7 | 7 | 0 |
| `user-service` | 54 | 33 | 30 | 21 | 23 | 1 |
| `portal-service` | 115 | 97 | 70 | 18 | 42 | 3 |
| 합계 | 203 | 157 | 127 | 46 | 72 | 4 |

수치를 정확히 적겠습니다. 이 수정으로 실패가 30건 줄어들며, 그 내역은 **통과로 전환된 것 26건**과 **`@Disabled`가 정상 인식된 것 4건**입니다. 후자는 소스에 `@Disabled`가 붙어 원래 실행 대상이 아닌 테스트인데, 수정 전에는 컨텍스트 기동 실패 때문에 실패로 집계되고 있었습니다. 해당 4건은 `RoleAuthorizationApiControllerTest.권한_인가_등록_조회()`, `BannerApiControllerTest.배너_등록()`, `CodeApiControllerTest.setup()`, `CodeDetailApiControllerTest.setup()`입니다.

통과로 전환된 26건은 `portal-service` 24건과 `user-service` 2건입니다. `portal-service`에서는 Hibernate `create-drop` DDL이 정상 수행되어 리포지토리 테스트가 동작합니다.

이 수정의 실질적 효과는 통과 건수 증가보다 **203건 전부가 컨텍스트를 기동하게 되는 것**에 있습니다. 수정 전 157건은 테스트 메서드 본문이 실행되지 않았으므로 검증 대상이 아니었습니다. 수정 후에는 전부 실행되고, 그 결과 남은 127건의 실패 원인이 드러납니다. 확인한 바로는 인가 위임 호출 실패, H2 예약어 관련 SQL 문법 오류, 개별 단정 실패로 나뉘며 서로 원인이 다릅니다. 이들은 이 PR의 범위가 아니고 별도로 확인하고 있습니다.

회귀는 없습니다. 수정 전에 통과하던 46건은 수정 후에도 전부 통과합니다.

설정 로드 동작 자체도 별도 프로브 테스트로 확인했습니다. `Environment`를 주입받아 `application.yml`에만 있는 키를 조회하는 방식입니다.

| 조건 | `info.app.name` (`application.yml`에만 있음) | `token.secret` (`application-test.yml`에 있음) |
|---|---|---|
| `@SpringBootTest` + `@ActiveProfiles("test")` | `"User Service"` | `"egovframe_token_secret"` |
| 위 + `spring.config.location=classpath:application-test.yml` | `null` | `"egovframe_token_secret"` |

두 번째 조건에서는 r2dbc 자동설정 3종을 별도로 제외해 컨텍스트를 기동시킨 뒤 설정 로드 여부만 확인했습니다. 컨텍스트가 뜬 상태에서도 `application.yml`의 키는 조회되지 않습니다. 이 프로브는 확인용이므로 이 PR에 포함하지 않았습니다.

측정하지 못한 것을 함께 적습니다. 세 서비스를 실제로 기동해 확인하지는 못했습니다. MySQL, Eureka, RabbitMQ, Config Server가 필요합니다. 이 PR은 `src/main`을 변경하지 않으므로 운영 동작에 영향이 없다고 판단했으나, 애노테이션 제거로 `bootstrap.yml`의 Config Server 설정이 다시 유효해지는 부분은 로그 수준까지 확인하지 않았습니다. 테스트 실행 시간은 `user-service` 2분 14초에서 2분 10초, `portal-service` 2분 13초로 유의한 차이가 없었습니다.

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

화면과 무관한 변경이라 선택하지 않았습니다. 변경한 파일은 백엔드 테스트 소스 29개이고 화면 코드와 프론트엔드는 수정하지 않았으므로 브라우저에서 확인할 대상이 없습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

화면 변경이 없어 첨부하지 않았습니다. 수정 전후 대조는 위 JUnit 절의 실행 결과 표로 확인하실 수 있습니다. 재현이 필요하시면 서비스별로 아래 명령을 수정 전후에 각각 실행하시면 같은 수치를 확인하실 수 있습니다.

```
cd backend/portal-service && ./gradlew test
```
