### PR TITLE
취소된 예약이 재고 겹침 계산에 포함돼 정상 신청이 거절되는 문제 수정

### DIFF
--- a/backend/reserve-request-service/src/main/java/org/egovframe/cloud/reserverequestservice/domain/ReserveRepositoryImpl.java
+++ b/backend/reserve-request-service/src/main/java/org/egovframe/cloud/reserverequestservice/domain/ReserveRepositoryImpl.java
@@ -59,6 +59,7 @@ public class ReserveRepositoryImpl implements ReserveRepositoryCustom {
             .matching(Query.query(where("reserve_item_id").is(reserveItemId)
                 .and ("reserve_start_date").lessThanOrEquals(endDate)
                 .and("reserve_end_date").greaterThanOrEquals(startDate)
+                .and("reserve_status_id").not(ReserveStatus.CANCEL.getKey())
             ))
             .all();
     }

--- a/backend/reserve-request-service/src/test/java/org/egovframe/cloud/reserverequestservice/domain/ReserveRepositoryImplTest.java
+++ b/backend/reserve-request-service/src/test/java/org/egovframe/cloud/reserverequestservice/domain/ReserveRepositoryImplTest.java
@@ -1,0 +1,105 @@
+package org.egovframe.cloud.reserverequestservice.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.r2dbc.core.R2dbcEntityTemplate;
+
+import io.r2dbc.h2.H2ConnectionConfiguration;
+import io.r2dbc.h2.H2ConnectionFactory;
+import io.r2dbc.h2.H2ConnectionOption;
+
+/**
+ * ReserveRepositoryImpl 단위 테스트
+ *
+ * findAllByReserveDate가 취소(cancel) 건을 조회 결과에서 제외하는지 검증한다.
+ * 같은 파일의 findAllByReserveDateCount는 이미 이 필터를 적용하고 있다.
+ *
+ * Spring 컨텍스트를 띄우지 않고 ReserveRepositoryImpl을 직접 생성해 임베디드 H2에
+ * 연결한다 - src/test/resources/schema-h2.sql은 별도 결함(COMMENT 절 · BIGINT(18))으로
+ * H2에서 파싱되지 않아 @SpringBootTest 컨텍스트 기동 자체가 실패하는 상태이며,
+ * 이 결함은 이 테스트가 검증하려는 대상(D-5)과 무관하므로 여기서는 우회한다.
+ */
+class ReserveRepositoryImplTest {
+
+    private R2dbcEntityTemplate entityTemplate;
+    private ReserveRepositoryImpl reserveRepositoryImpl;
+
+    private static final Long RESERVE_ITEM_ID = 100L;
+    private static final LocalDateTime QUERY_START = LocalDateTime.of(2026, 8, 10, 0, 0);
+    private static final LocalDateTime QUERY_END = LocalDateTime.of(2026, 8, 12, 0, 0);
+
+    @BeforeEach
+    void setUp() {
+        H2ConnectionFactory connectionFactory = new H2ConnectionFactory(
+            H2ConnectionConfiguration.builder()
+                .inMemory("reserve_repository_impl_test")
+                .property(H2ConnectionOption.DB_CLOSE_DELAY, "-1")
+                .username("sa")
+                .build());
+
+        entityTemplate = new R2dbcEntityTemplate(connectionFactory);
+
+        entityTemplate.getDatabaseClient()
+            .sql("CREATE TABLE reserve ("
+                + "reserve_id VARCHAR(255) NOT NULL,"
+                + "reserve_item_id BIGINT,"
+                + "reserve_qty INT,"
+                + "reserve_start_date TIMESTAMP,"
+                + "reserve_end_date TIMESTAMP,"
+                + "reserve_status_id VARCHAR(20),"
+                + "PRIMARY KEY (reserve_id))")
+            .then()
+            .block();
+
+        reserveRepositoryImpl = new ReserveRepositoryImpl(entityTemplate);
+    }
+
+    @AfterEach
+    void tearDown() {
+        entityTemplate.getDatabaseClient().sql("DROP TABLE reserve").then().block();
+    }
+
+    private void insertReserve(String reserveId, String reserveStatusId, int reserveQty) {
+        reserveRepositoryImpl.insert(Reserve.builder()
+            .reserveId(reserveId)
+            .reserveItemId(RESERVE_ITEM_ID)
+            .reserveQty(reserveQty)
+            .reserveStartDate(QUERY_START)
+            .reserveEndDate(QUERY_END)
+            .reserveStatusId(reserveStatusId)
+            .build()).block();
+    }
+
+    @Test
+    void 취소된_예약은_기간_겹침_조회_결과에서_제외된다() {
+        insertReserve("cancelled-1", ReserveStatus.CANCEL.getKey(), 5);
+        insertReserve("active-1", ReserveStatus.REQUEST.getKey(), 3);
+
+        List<Reserve> result = reserveRepositoryImpl
+            .findAllByReserveDate(RESERVE_ITEM_ID, QUERY_START, QUERY_END)
+            .collectList()
+            .block();
+
+        assertThat(result)
+            .extracting(Reserve::getReserveId)
+            .containsExactly("active-1");
+    }
+
+    @Test
+    void 취소된_예약만_있으면_조회_결과가_비어있다() {
+        insertReserve("cancelled-1", ReserveStatus.CANCEL.getKey(), 5);
+
+        List<Reserve> result = reserveRepositoryImpl
+            .findAllByReserveDate(RESERVE_ITEM_ID, QUERY_START, QUERY_END)
+            .collectList()
+            .block();
+
+        assertThat(result).isEmpty();
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

취소된 예약이 `reserve-request-service`의 기간 겹침 조회에 그대로 포함되어, 실제로는 재고가 비어 있는데도 신규 장비 예약 신청이 부당하게 거절됩니다.

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

### 원인

`reserve-check-service`와 `reserve-request-service`는 같은 `reservation.reserve` 테이블을 각자의 R2DBC 리포지토리로 직접 조회합니다(`backend/config/config/reserve-check-service.yml:3`, `backend/config/config/reserve-request-service.yml:3`가 같은 `r2dbc:mysql://.../reservation` URL을 가리키고, 두 서비스의 `Reserve.java`가 똑같이 `@Table("reserve")`를 선언합니다). "물품·기간이 겹치는 예약을 조회한다"는 같은 시맨틱을 구현한 메서드가 두 서비스에 총 4개 있는데, 그중 3개는 `reserve_status_id != cancel` 조건으로 취소 건을 제외하고, 1개만 이 조건이 빠져 있습니다.

| 서비스 | 메서드 | 파일:줄(`upstream/main` 기준) | 취소 제외 필터 |
|---|---|---|---|
| `reserve-check-service` | `findAllByReserveDate` | `ReserveRepositoryImpl.java:172-180` | 있음 (177행) |
| `reserve-check-service` | `findAllByReserveDateWithoutSelf` | 동 파일 `192-201` | 있음 (198행) |
| `reserve-check-service` | `findAllByReserveDateWithoutSelfCount` | 동 파일 `213-222` | 있음 (219행) |
| `reserve-request-service` | `findAllByReserveDateCount` | `ReserveRepositoryImpl.java:76-84` | 있음 (81행) |
| `reserve-request-service` | **`findAllByReserveDate`** | 동 파일 `57-64` | **없음** |

수정 대상인 `findAllByReserveDate`(수정 전)입니다.

```java
// backend/reserve-request-service/.../domain/ReserveRepositoryImpl.java:57-64 (수정 전)
public Flux<Reserve> findAllByReserveDate(Long reserveItemId, LocalDateTime startDate, LocalDateTime endDate) {
    return entityTemplate.select(Reserve.class)
        .matching(Query.query(where("reserve_item_id").is(reserveItemId)
            .and ("reserve_start_date").lessThanOrEquals(endDate)
            .and("reserve_end_date").greaterThanOrEquals(startDate)
        ))
        .all();
}
```

같은 파일의 `findAllByReserveDateCount`(76-84행)는 동일한 조회 조건에 `reserve_status_id` 필터만 추가로 갖고 있습니다.

### 호출 경로

`findAllByReserveDate`는 `ReserveValidator` 안에서 한 곳에서만 호출됩니다(`grep -rn "findAllByReserveDate\b" src/main` 결과, `ReserveRepositoryCustom`·`ReserveRepositoryImpl`의 선언부를 빼면 호출부는 1곳입니다).

```
POST /api/v1/requests/evaluates  (categoryId=equipment, 실시간 장비 예약)
  → ReserveValidator.checkValidation → checkEquipment                 // ReserveValidator.java:101
      → getMaxByReserveDate(reserveItemId, startDate, endDate)         // :132
          → reserveRepository.findAllByReserveDate(...)                // :133  ← 필터 없는 메서드
          → isOverlapped()로 겹치는 예약의 reserveQty 합산 → max
      → if (totalQty - max) < reserveQty  → 거부                       // :108
```

공간 예약 경로(`checkSpace` → `findAllByReserveDateCount`)는 이미 필터가 있는 메서드를 쓰므로 이 결함의 영향을 받지 않습니다. 영향은 장비(`categoryId=equipment`) 예약 경로로 한정됩니다.

### 재현 시나리오

장비 A(재고 5개)에 대해 2026-08-10~08-12 기간으로 사용자 갑이 5개를 예약했다가 취소한 뒤, 사용자 을이 같은 물품·같은 기간에 3개를 신청하는 경우입니다.

| 단계 | `reserve` 테이블 상태 | `findAllByReserveDate`가 돌려주는 값(수정 전) | 실제로 맞는 값 |
|---|---|---|---|
| 갑이 5개 예약 후 취소 | `reserve_status_id='cancel'`인 행이 남음 | - | 재고 5개 전부 사용 가능 |
| 을이 3개 신청 | 조회 시 갑의 취소 행도 포함됨 | `max=5` → `totalQty(5) - max(5) = 0 < 3` → **거절** | 5개 전부 비어 있으므로 **승인돼야 함** |

같은 순간 `reserve-check-service`의 조회 API로 같은 물품·기간을 조회하면 취소 건이 제외되어 다른(더 큰) 잔여 수량이 나옵니다 — 같은 테이블을 보는 두 서비스가 서로 다른 답을 냅니다.

### 수정

같은 파일의 `findAllByReserveDateCount`가 이미 쓰는 조건을 `findAllByReserveDate`에도 그대로 추가했습니다. `ReserveStatus`는 이미 같은 패키지에 있고 `findAllByReserveDateCount`가 이미 참조하고 있어 추가 의존성이나 신규 import가 없습니다.

```diff
     public Flux<Reserve> findAllByReserveDate(Long reserveItemId, LocalDateTime startDate, LocalDateTime endDate) {
         return entityTemplate.select(Reserve.class)
             .matching(Query.query(where("reserve_item_id").is(reserveItemId)
                 .and ("reserve_start_date").lessThanOrEquals(endDate)
                 .and("reserve_end_date").greaterThanOrEquals(startDate)
+                .and("reserve_status_id").not(ReserveStatus.CANCEL.getKey())
             ))
             .all();
     }
```

`src/main` 변경은 이 1줄뿐입니다. 승인·취소 API 자체의 상태 전이(중복 승인/취소 시 재고가 재차 증감되는 문제)는 `reserve-check-service`의 별개 결함이라 이번 PR에서는 다루지 않았습니다.

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

### 재현 테스트 추가

`ReserveRepositoryImplTest`를 새로 추가했습니다. `reserve-check-service`와 달리 `reserve-request-service`의 `src/test/resources/schema-h2.sql`은 `COMMENT` 절과 `BIGINT(18)` 표기 때문에 H2에서 파싱되지 않아, 기존 `ReserveApiControllerTest`처럼 `@SpringBootTest`로 전체 컨텍스트를 띄우는 방식은 이 결함과 무관한 이유로 기동 자체가 실패합니다(아래 "측정" 절 참고). 그래서 `ReserveRepositoryImpl`을 Spring 컨텍스트 없이 직접 생성해 임베디드 H2에 연결하는 순수 단위 테스트로 작성했습니다. 취소 건과 활성 건을 함께 넣고 조회했을 때 취소 건만 제외되는지, 취소 건만 있을 때 결과가 비는지 두 가지를 검증합니다.

### 수정 전(RED) / 수정 후(GREEN) 대조

새 테스트만 골라 실행한 결과입니다. JDK 21(`sourceCompatibility=17`), Gradle Wrapper 8.5.

```
cd backend/reserve-request-service
./gradlew test --tests "org.egovframe.cloud.reserverequestservice.domain.ReserveRepositoryImplTest"
```

| 시점 | 결과 |
|---|---|
| 수정 전 (필터 추가 전 `ReserveRepositoryImpl` + 새 테스트) | 2개 중 2개 **실패** — 취소 건이 조회 결과에 포함됨 |
| 수정 후 (필터 추가 후) | 2개 중 2개 **통과** |

### 회귀 확인 — 모듈 전체 테스트 수정 전후 대조

```
cd backend/reserve-request-service
./gradlew test
```

| 시점 | 전체 | 실패 | 통과 |
|---|---|---|---|
| 수정 전 (새 테스트 파일 추가 이전 원본 상태) | 21 | 2 | 19 |
| 수정 후 (새 테스트 2건 포함) | 23 | 2 | 21 |

수정 전후 모두 실패하는 2건(`ReserveRequestServiceApplicationTests.contextLoads()`, `ReserveApiControllerTest`)은 이 PR과 무관한 기존 결함입니다. `src/test/resources/schema-h2.sql`의 `CREATE TABLE reserve (... COMMENT '예약 id' ...)` 구문과 `BIGINT(18)` 표기를 H2가 파싱하지 못해 `@SpringBootTest` 컨텍스트 기동 자체가 실패합니다(`R2dbcBadGrammarException` → `JdbcSQLSyntaxErrorException`). 이 PR은 이 파일을 건드리지 않았고, 수정 전후 실패 건수·대상이 동일함을 확인했습니다. 새로 추가한 2건은 이 실패와 무관하게 Spring 컨텍스트를 띄우지 않는 방식으로 작성했기 때문에 정상적으로 통과합니다.

### 측정하지 못한 것

- MySQL·Eureka·RabbitMQ·Config Server를 띄운 실제 서비스 간 통합 재현(사용자 갑/을 시나리오를 실제 HTTP 요청으로)은 하지 않았습니다. 리포지토리 계층 단위 테스트로 원인과 수정을 확정했습니다.
- 위에서 설명한 `schema-h2.sql`의 H2 파싱 결함 자체는 이 PR의 범위가 아니라 별도로 남겨둡니다.

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

백엔드 리포지토리 쿼리 조건 수정이라 브라우저에서 확인할 화면 변경이 없어 선택하지 않았습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

화면 변경이 없어 첨부하지 않았습니다. 수정 전후 대조는 위 JUnit 테스트 절의 실행 결과 표로 확인하실 수 있습니다.
