### PR TITLE
fix(portal-service): 링크 메뉴의 URL 필수 검증이 단락평가로 무효화되는 문제 수정

### DIFF
--- a/backend/portal-service/src/main/java/org/egovframe/cloud/portalservice/api/menu/dto/MenuUpdateRequestDto.java
+++ b/backend/portal-service/src/main/java/org/egovframe/cloud/portalservice/api/menu/dto/MenuUpdateRequestDto.java
@@ -71,7 +71,7 @@ public class MenuUpdateRequestDto {
 
     public boolean hasUrlPath() {
         if ("inside".equals(menuType) || "outside".equals(menuType)) {
-            return Objects.nonNull(urlPath) || StringUtils.hasText(urlPath);
+            return Objects.nonNull(urlPath) && StringUtils.hasText(urlPath);
         }
         return true;
     }

--- a/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/api/menu/dto/MenuUpdateRequestDtoTest.java
+++ b/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/api/menu/dto/MenuUpdateRequestDtoTest.java
@@ -1,0 +1,44 @@
+package org.egovframe.cloud.portalservice.api.menu.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link MenuUpdateRequestDto#hasUrlPath()}의 링크 URL 필수 검증을 확인한다.
+ *
+ * <p>내부·외부 링크 메뉴는 링크 URL이 필수다. MenuService가 이 메서드의 결과로
+ * "링크 Url 값은 필수 입니다" 예외를 던진다.
+ */
+class MenuUpdateRequestDtoTest {
+
+    private MenuUpdateRequestDto dto(String menuType, String urlPath) {
+        return MenuUpdateRequestDto.builder()
+                .menuKorName("메뉴")
+                .menuType(menuType)
+                .urlPath(urlPath)
+                .build();
+    }
+
+    @Test
+    @DisplayName("내부링크에 공백만 있는 URL은 필수 검증을 통과하지 못한다")
+    void blankUrlPathIsRejected() {
+        assertThat(dto("inside", "   ").hasUrlPath()).isFalse();
+        assertThat(dto("outside", "").hasUrlPath()).isFalse();
+    }
+
+    @Test
+    @DisplayName("내부·외부링크에 URL이 없으면 필수 검증을 통과하지 못한다")
+    void nullUrlPathIsRejected() {
+        assertThat(dto("inside", null).hasUrlPath()).isFalse();
+        assertThat(dto("outside", null).hasUrlPath()).isFalse();
+    }
+
+    @Test
+    @DisplayName("URL이 있으면 통과하고, 링크 유형이 아니면 검증 대상이 아니다")
+    void validUrlPathAndOtherMenuTypesPass() {
+        assertThat(dto("inside", "/portal/main").hasUrlPath()).isTrue();
+        assertThat(dto("contents", null).hasUrlPath()).isTrue();
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`MenuUpdateRequestDto.hasUrlPath()`는 `StringUtils.hasText()`로 "공백이 아닌 실제 텍스트"를 확인하겠다고 코드로 선언해 놓고, 그 앞에 `||` 를 써서 스스로 무효화합니다.

```java
public boolean hasUrlPath() {
    if ("inside".equals(menuType) || "outside".equals(menuType)) {
        return Objects.nonNull(urlPath) || StringUtils.hasText(urlPath);
    }
    return true;
}
```

`urlPath`가 null이 아니면 왼쪽이 참이라 단락평가로 `hasText()`가 실행되지 않습니다. 결국 이 메서드는 `urlPath != null` 과 같고, 공백만 있는 문자열도 "URL 있음"으로 통과시킵니다.

`MenuService:181`이 이 결과로 예외를 던지므로, 내부·외부 링크 메뉴를 공백 URL로 저장할 수 있습니다.

```java
// 내부링크 or 외부링크인 경우 링크 url 필수
if (!updateRequestDto.hasUrlPath()) {
    throw new BusinessMessageException(getMessage("valid.required", ...));  // 링크 Url 값은 필수 입니다
}
```

저장된 값은 그대로 화면에 나갑니다. 포털의 `Header`·`Footer`·`SideBar`·`Sitemap`이 `urlPath`를 `href`에 바로 넣고 별도 가드가 없어, 목적지 없는 링크가 공개 화면에 걸립니다.

AS-IS / TO-BE

```diff
-            return Objects.nonNull(urlPath) || StringUtils.hasText(urlPath);
+            return Objects.nonNull(urlPath) && StringUtils.hasText(urlPath);
```

같은 패턴을 `||` → `&&` 로 고친 선례가 같은 `api/menu/dto` 패키지에 있습니다 — `MenuSideResponseDto.hasChildren()`(#89).

### 범위

같은 형태가 두 곳 더 있습니다(`AttachmentTempSaveRequestDto.hasUniqueId`, `Attachment.hasEntityId`). 두 값은 서버가 `UUID`로 만들거나 내부 API·이벤트 스트림으로만 채워져 공백이 들어오는 경로를 찾지 못해 이번 범위에서 뺐습니다. `urlPath`는 사용자가 직접 입력하는 필수 항목이라 성격이 다릅니다.

메뉴 생성 경로(`MenuTreeRequestDto`)에는 `urlPath`·`menuType` 필드 자체가 없어 같은 구멍이 없습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

`MenuUpdateRequestDtoTest` 3건을 추가했습니다(Spring 컨텍스트 없는 POJO 테스트).

수정 지점만 되돌린 상태(RED) — 공백 케이스만 실패합니다. null은 원래 걸립니다.

```
MenuUpdateRequestDtoTest > 내부링크에 공백만 있는 URL은 필수 검증을 통과하지 못한다 FAILED
    org.opentest4j.AssertionFailedError at MenuUpdateRequestDtoTest.java:27
3 tests completed, 1 failed
```

수정 후(GREEN)

```
tests="3" skipped="0" failures="0" errors="0"
```

`MenuRepositoryTest`도 3/3 통과합니다. 다만 이 모듈의 `*ApiControllerTest`는 로컬에서 `Table "menu" not found`로 실패하는데, 이 변경 전 `main`에서도 동일하게 10/10 실패하는 기존 상태라 이번 변경과 무관합니다.

## 테스트 브라우저 Test Browser

백엔드 DTO 검증 로직 수정이라 브라우저와 무관합니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면 변경이 없어 첨부하지 않았습니다.
