### PR TITLE
fix(portal): message만 담긴 에러 상태가 화면에 표시되지 않는 문제 수정

### DIFF
--- a/frontend/portal/src/components/Wrapper/GlobalError.tsx
+++ b/frontend/portal/src/components/Wrapper/GlobalError.tsx
@@ -36,7 +36,7 @@ const GlobalError = () => {
   })
 
   useEffect(() => {
-    if (errorState.error) {
+    if (errorState.error || errorState.message) {
       if (errorState.status === 400) {
         const errors = errorState.errors.map(item => {
           return item.defaultMessage
@@ -55,7 +55,7 @@ const GlobalError = () => {
     }
   }, [errorState])
 
-  if (!errorState.error) return null
+  if (!errorState.error && !errorState.message) return null
 
   const resetError = () => {
     setAlertState({


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`errorStateSelector`는 `error` 객체 없이 `message`만 넘겨도 정상 처리합니다.

```ts
let message = error?.message || newValue.message || DEFAULT_ERROR_MESSAGE
```

`IErrorProps`도 `error`와 `message`를 모두 옵셔널로 선언합니다. 그런데 유일한 소비자인 `GlobalError`는 `errorState.error`가 truthy일 때만 `useEffect`를 돌리고 렌더도 하므로, `message`만 넣은 호출은 아무것도 하지 않고 사라집니다.

portal에서 `message`만 넣는 호출은 11곳입니다.

```
pages/user/password/index.tsx:112,134,153   소셜 계정 재확인 실패
pages/user/leave/index.tsx:100,112,124      소셜 계정 재확인 실패
pages/user/info/index.tsx:154,176,195       소셜 계정 재확인 실패
components/Reserve/ReserveEdit.tsx:169,194  예약 저장 응답이 falsy일 때
```

앞의 9곳은 연동된 계정과 다른 카카오·네이버·구글 계정으로 재인증할 때입니다. 어느 경우든 안내가 전혀 뜨지 않아 화면이 멈춘 것처럼 보입니다.

AS-IS / TO-BE

```diff
   useEffect(() => {
-    if (errorState.error) {
+    if (errorState.error || errorState.message) {

-  if (!errorState.error) return null
+  if (!errorState.error && !errorState.message) return null
```

### 영향 범위

리셋 경로는 영향받지 않습니다. `resetError`는 셀렉터가 아니라 atom에 직접 쓰므로(`useRecoilState(errorStateAtom)`) `message`가 빈 문자열이 되고, atom 기본값에도 `message`가 없습니다.

`admin`은 이 수정이 필요 없습니다. `message`만 넣는 호출이 없을 뿐 아니라 admin의 셀렉터에는 `newValue.message` 폴백 자체가 없어 게이트만 고쳐도 동작하지 않습니다.

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

portal의 jest 설정에는 `@components`·`@stores` 별칭 매핑과 jsdom 환경이 없어 컴포넌트 테스트를 그대로 추가할 수 없습니다. 그래서 임시로 그 두 가지를 붙인 하네스로 로컬에서만 확인하고 되돌렸습니다.

수정 전 — 스낵바가 호출되지 않습니다.

```
✕ message만 담긴 에러도 사용자에게 표시한다
  Expected: "계정이 일치하지 않습니다", ObjectContaining {"variant": "error"}
  Number of calls: 0
```

수정 후

```
✓ message만 담긴 에러도 사용자에게 표시한다
✓ 리셋 직후 상태에서는 아무것도 띄우지 않는다
✓ 기본 상태에서도 아무것도 띄우지 않는다
Tests: 3 passed, 3 total
```

기존 테스트 3개 스위트 35건은 그대로 통과합니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer

브라우저 실행 없이 컴포넌트 단위로 확인했습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

수정 전에는 아무것도 표시되지 않아 비교 화면을 첨부하기 어렵습니다.
