### PR TITLE
fix(portal-service): 이미지 파일 로딩 오류 수정

### DIFF
--- a/backend/portal-service/src/main/java/org/egovframe/cloud/portalservice/utils/FileStorageUtils.java
+++ b/backend/portal-service/src/main/java/org/egovframe/cloud/portalservice/utils/FileStorageUtils.java
@@ -2,10 +2,7 @@ package org.egovframe.cloud.portalservice.utils;
 
 import static org.egovframe.cloud.portalservice.utils.PortalUtils.getPhysicalFileName;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -419,29 +416,21 @@ public class FileStorageUtils implements StorageUtils {
     public AttachmentImageResponseDto loadImage(String imagename) {
         try {
             Path imagePath = resolvePathUnderFileStorage(imagename);
-            try (InputStream is = new FileInputStream(imagePath.toFile())) {
-                try (ByteArrayOutputStream buffer = new ByteArrayOutputStream()) {
-                    int read;
-                    byte[] data = new byte[(int) imagePath.toFile().length()];
-                    while ((read = is.read(data, 0, data.length)) != -1) {
-                        buffer.write(data, 0, read);
-                    }
+            byte[] data = Files.readAllBytes(imagePath);
 
-                    // /image/* 만 허용(저장형 XSS 방지)
-                    String mimeType = probeContentType(imagePath);
-                    if (mimeType == null || !mimeType.toLowerCase(Locale.ROOT).startsWith("image/")) {
-                        log.warn("Rejected non-image content type on image load: {}", mimeType);
-                        throw new BusinessMessageException(messageUtil.getMessage("valid.file.invalid_name"));
-                    }
-
-                    return AttachmentImageResponseDto.builder()
-                            .mimeType(mimeType)
-                            .data(data)
-                            .build();
-                }
+            // /image/* 만 허용(저장형 XSS 방지)
+            String mimeType = probeContentType(imagePath);
+            if (mimeType == null || !mimeType.toLowerCase(Locale.ROOT).startsWith("image/")) {
+                log.warn("Rejected non-image content type on image load: {}", mimeType);
+                throw new BusinessMessageException(messageUtil.getMessage("valid.file.invalid_name"));
             }
 
-        } catch (FileNotFoundException | NoSuchFileException ex) {
+            return AttachmentImageResponseDto.builder()
+                    .mimeType(mimeType)
+                    .data(data)
+                    .build();
+
+        } catch (NoSuchFileException ex) {
             // 파일을 찾을 수 없습니다.
             throw new BusinessMessageException(messageUtil.getMessage("valid.file.not_found"));
         } catch (IOException iex) {

--- a/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/utils/FileStorageUtilsTest.java
+++ b/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/utils/FileStorageUtilsTest.java
@@ -1,0 +1,55 @@
+package org.egovframe.cloud.portalservice.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.egovframe.cloud.common.util.MessageUtil;
+import org.egovframe.cloud.portalservice.api.attachment.dto.AttachmentImageResponseDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.mock.env.MockEnvironment;
+
+class FileStorageUtilsTest {
+
+    @TempDir
+    Path storageDirectory;
+
+    private FileStorageUtils fileStorageUtils;
+
+    @BeforeEach
+    void setUp() {
+        MockEnvironment environment = new MockEnvironment()
+                .withProperty("file.directory", storageDirectory.toString())
+                .withProperty(FileStorageUtils.PROPERTY_ALLOWED_EXTENSIONS, "png");
+        fileStorageUtils = new FileStorageUtils(environment, mock(MessageUtil.class));
+    }
+
+    @Test
+    void loadImageReturnsEveryStoredByte() throws IOException {
+        byte[] imageBytes = new byte[] {
+                (byte) 0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+                0x01, 0x02, 0x03, 0x04
+        };
+        Files.write(storageDirectory.resolve("image.png"), imageBytes);
+
+        AttachmentImageResponseDto image = fileStorageUtils.loadImage("image.png");
+
+        assertThat(image.getMimeType()).startsWith("image/");
+        assertThat(image.getData()).containsExactly(imageBytes);
+    }
+
+    @Test
+    void loadImageReturnsImmediatelyForEmptyImage() throws IOException {
+        Files.createFile(storageDirectory.resolve("empty.png"));
+
+        AttachmentImageResponseDto image = fileStorageUtils.loadImage("empty.png");
+
+        assertThat(image.getMimeType()).startsWith("image/");
+        assertThat(image.getData()).isEmpty();
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [x] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

###  개요

이미지 파일을 불완전하게 반환하거나 빈 파일을 읽을 때 반복문이 종료되지 않을 수 있는 문제를 수정합니다.

###  변경 사항

- 이미지 파일을 `Files.readAllBytes()`로 읽도록 변경
- 불필요한 `FileInputStream` 및 `ByteArrayOutputStream` 제거
- 정상 이미지의 전체 바이트 반환 테스트 추가
- 빈 이미지 파일 로딩 회귀 테스트 추가

###  문제 원인

기존 구현은 파일 크기만큼 생성한 배열을 읽기 버퍼로 사용하면서 별도의 `ByteArrayOutputStream`에 실제 데이터를 저장했습니다. 하지만 응답에는 `ByteArrayOutputStream`의 결과가 아닌 읽기 버퍼를 반환했습니다.

또한 빈 파일은 길이가 0인 배열로 읽기를 반복하면서 `read()`가 `0`을 반환하므로 반복문이 종료되지 않을 수 있었습니다.

###  해결 방법

`Files.readAllBytes()`를 사용해 파일 전체를 한 번에 읽도록 단순화했습니다.

이를 통해 다음 문제를 해결합니다.

- 부분 읽기로 인한 이미지 데이터 손상
- 빈 파일을 읽을 때 발생할 수 있는 무한 루프
- 불필요한 출력 버퍼 및 중첩 스트림 처리

기존 저장 경로 및 MIME 타입 검증은 유지합니다.

###  테스트

```text
./gradlew test --tests org.egovframe.cloud.portalservice.utils.FileStorageUtilsTest
```

검증 항목:

- 정상 이미지의 모든 바이트가 동일하게 반환되는지 확인
- 빈 이미지가 즉시 반환되는지 확인

테스트 결과:

```text
BUILD SUCCESSFUL
```

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [x] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.
