### PR TITLE
fix(portal): 텍스트 영역의 한글 길이 제한 오류 수정

### DIFF
--- a/frontend/portal/src/hooks/useTextarea.ts
+++ b/frontend/portal/src/hooks/useTextarea.ts
@@ -1,5 +1,5 @@
 import { COMMENTS_MAX_LENGTH } from '@constants'
-import { getTextLength } from '@utils'
+import { getTextLength, truncateText } from '@utils'
 import React, { useState } from 'react'
 
 export interface ITextarea {
@@ -15,12 +15,13 @@ export default function useTextarea(
   const max = maxLength
 
   const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
-    let targetValue = event.target.value
+    const targetValue = event.target.value
     const count = getTextLength(targetValue)
     if (count > max) {
+      const truncatedValue = truncateText(targetValue, max)
       setTextarea({
-        value: targetValue.slice(0, max),
-        currentCount: max,
+        value: truncatedValue,
+        currentCount: getTextLength(truncatedValue),
       })
 
       return

--- a/frontend/portal/src/utils/__tests__/utils.test.ts
+++ b/frontend/portal/src/utils/__tests__/utils.test.ts
@@ -4,6 +4,7 @@ import {
   getTextLength,
   isValidPassword,
   rownum,
+  truncateText,
   translateToLang,
 } from '../index'
 import { Page } from '@service'
@@ -61,6 +62,20 @@ describe('getTextLength', () => {
   it('빈 문자열은 0이다', () => {
     expect(getTextLength('')).toBe(0)
     expect(getTextLength('', 'char')).toBe(0)
+  })
+})
+
+describe('truncateText', () => {
+  it('truncates ASCII text at the byte limit', () => {
+    expect(truncateText('abcdef', 4)).toBe('abcd')
+  })
+
+  it('truncates Korean text using its weighted length', () => {
+    expect(truncateText('한글텍스트', 5)).toBe('한글')
+  })
+
+  it('does not split a Unicode surrogate pair', () => {
+    expect(truncateText('a😀b', 2)).toBe('a😀')
   })
 })
 

--- a/frontend/portal/src/utils/index.ts
+++ b/frontend/portal/src/utils/index.ts
@@ -46,6 +46,25 @@ export const getTextLength = (
   return len
 }
 
+export const truncateText = (
+  str: string,
+  maxLength: number,
+  format: 'byte' | 'char' = 'byte',
+) => {
+  let result = ''
+  let length = 0
+
+  for (const character of str) {
+    const characterLength = getTextLength(character, format)
+    if (length + characterLength > maxLength) break
+
+    result += character
+    length += characterLength
+  }
+
+  return result
+}
+
 // 텍스트 포멧
 export const format = (text: string, args: any[]) =>
   text.replace(/{(\d+)}/g, (match, number) =>


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [x] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

###  개요

텍스트 영역에서 한글이 포함된 입력값의 길이 제한이 올바르게 적용되지 않는 문제를 수정합니다.

###  문제 원인

`getTextLength()`는 한글을 2바이트로 계산하지만, 최대 길이를 초과했을 때는 JavaScript의 `slice(0, maxLength)`를 사용했습니다.

`slice()`는 가중 길이가 아닌 문자 인덱스를 기준으로 동작하기 때문에 한글 입력값이 실제 제한 길이를 초과한 상태로 남을 수 있었습니다. 또한 화면에 표시되는 현재 길이와 실제 입력값의 길이가 일치하지 않을 수 있었습니다.

###  변경 사항

- 가중 길이를 기준으로 문자열을 자르는 `truncateText()` 유틸리티 추가
- `useTextarea`에서 `slice()` 대신 `truncateText()` 사용
- 잘린 문자열을 기준으로 `currentCount` 재계산
- 영문 문자열 길이 제한 테스트 추가
- 한글 문자열 가중 길이 제한 테스트 추가
- 유니코드 surrogate pair 경계 테스트 추가

###  영향

- 한글이 포함된 입력값에도 최대 길이가 정확하게 적용됩니다.
- 현재 글자 수와 실제 입력값의 길이가 일치합니다.
- 유니코드 문자가 문자열 절단 과정에서 분리되는 것을 방지합니다.

###  테스트

```text
npm test -- --runInBand src/utils/__tests__/utils.test.ts
```

검증 항목:

- 영문 문자열이 제한 길이에서 잘리는지 확인
- 한글 문자열이 가중 길이를 기준으로 잘리는지 확인
- 유니코드 surrogate pair가 분리되지 않는지 확인

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.
