### PR TITLE
fix(apigateway): 인가 요청의 블로킹 호출 제거

### DIFF
--- a/backend/apigateway/src/main/java/org/egovframe/cloud/apigateway/config/ReactiveAuthorization.java
+++ b/backend/apigateway/src/main/java/org/egovframe/cloud/apigateway/config/ReactiveAuthorization.java
@@ -51,6 +51,8 @@ import reactor.core.publisher.Mono;
 @Component
 public class ReactiveAuthorization implements ReactiveAuthorizationManager<AuthorizationContext> {
 
+    private final WebClient.Builder webClientBuilder;
+
     @Value("${apigateway.host:http://localhost:8000}")
     private String APIGATEWAY_HOST;
 
@@ -133,23 +135,21 @@ public class ReactiveAuthorization implements ReactiveAuthorizationManager<Autho
             }
         }
 
-        boolean granted = false;
-        try {
-            String token = authorizationHeader; // Variable used in lambda expression should be final or effectively final
-            Mono<Boolean> body = WebClient.create(baseUrl)
-                .get()
-                .headers(httpHeaders -> {
-                    httpHeaders.add(HttpHeaders.AUTHORIZATION, token);
-                })
-                .retrieve().bodyToMono(Boolean.class);
-            granted = body.toFuture().get().booleanValue();
-            log.info("Security AuthorizationDecision granted={}", granted);
-        } catch (Exception e) {
-            log.error("인가 서버에 요청 중 오류 : {}", e.getMessage());
-            throw new AuthorizationServiceException("인가 요청시 오류 발생");
-        }
-
-        return Mono.just(new AuthorizationDecision(granted));
+        String token = authorizationHeader;
+        return webClientBuilder.clone()
+            .baseUrl(baseUrl)
+            .build()
+            .get()
+            .headers(httpHeaders -> httpHeaders.add(HttpHeaders.AUTHORIZATION, token))
+            .retrieve()
+            .bodyToMono(Boolean.class)
+            .defaultIfEmpty(false)
+            .doOnNext(granted -> log.info("Security AuthorizationDecision granted={}", granted))
+            .map(AuthorizationDecision::new)
+            .onErrorMap(e -> {
+                log.error("인가 서버에 요청 중 오류 : {}", e.getMessage());
+                return new AuthorizationServiceException("인가 요청시 오류 발생", e);
+            });
     }
 
 }

--- a/backend/apigateway/src/test/java/org/egovframe/cloud/apigateway/config/ReactiveAuthorizationUnitTest.java
+++ b/backend/apigateway/src/test/java/org/egovframe/cloud/apigateway/config/ReactiveAuthorizationUnitTest.java
@@ -1,0 +1,83 @@
+package org.egovframe.cloud.apigateway.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.security.access.AuthorizationServiceException;
+import org.springframework.security.web.server.authorization.AuthorizationContext;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import reactor.core.publisher.Mono;
+
+class ReactiveAuthorizationUnitTest {
+
+    @Test
+    void grantsAccessWhenAuthorizationServerReturnsTrue() {
+        ReactiveAuthorization authorization = authorizationReturning("true");
+
+        assertThat(authorization.check(Mono.empty(), authorizationContext()).block())
+                .matches(decision -> decision != null && decision.isGranted());
+    }
+
+    @Test
+    void deniesAccessWhenAuthorizationServerReturnsFalse() {
+        ReactiveAuthorization authorization = authorizationReturning("false");
+
+        assertThat(authorization.check(Mono.empty(), authorizationContext()).block())
+                .matches(decision -> decision != null && !decision.isGranted());
+    }
+
+    @Test
+    void deniesAccessWhenAuthorizationServerReturnsEmptyBody() {
+        ReactiveAuthorization authorization = authorizationReturning("");
+
+        assertThat(authorization.check(Mono.empty(), authorizationContext()).block())
+                .matches(decision -> decision != null && !decision.isGranted());
+    }
+
+    @Test
+    void mapsAuthorizationServerFailureToAuthorizationServiceException() {
+        ExchangeFunction exchangeFunction = request -> Mono.error(new IllegalStateException("connection failed"));
+        ReactiveAuthorization authorization = authorizationWith(exchangeFunction);
+
+        assertThatThrownBy(() -> authorization.check(Mono.empty(), authorizationContext()).block())
+                .isInstanceOf(AuthorizationServiceException.class)
+                .hasCauseInstanceOf(IllegalStateException.class);
+    }
+
+    private ReactiveAuthorization authorizationReturning(String responseBody) {
+        ExchangeFunction exchangeFunction = request -> {
+            ClientResponse.Builder response = ClientResponse
+                    .create(HttpStatus.OK)
+                    .header("Content-Type", MediaType.APPLICATION_JSON_VALUE);
+            if (!responseBody.isEmpty()) {
+                response.body(responseBody);
+            }
+            return Mono.just(response.build());
+        };
+        return authorizationWith(exchangeFunction);
+    }
+
+    private ReactiveAuthorization authorizationWith(ExchangeFunction exchangeFunction) {
+        ReactiveAuthorization authorization = new ReactiveAuthorization(
+                WebClient.builder().exchangeFunction(exchangeFunction));
+        ReflectionTestUtils.setField(authorization, "APIGATEWAY_HOST", "http://localhost:8000");
+        ReflectionTestUtils.setField(authorization, "TOKEN_SECRET", "test-token-secret");
+        return authorization;
+    }
+
+    private AuthorizationContext authorizationContext() {
+        MockServerHttpRequest request = MockServerHttpRequest
+                .get("/user-service/api/v1/users")
+                .build();
+        return new AuthorizationContext(MockServerWebExchange.from(request));
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [x] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

###  개요

API Gateway의 인가 서버 요청을 논블로킹 방식으로 처리하도록 개선합니다.

###  문제 원인

기존 `ReactiveAuthorization`은 `WebClient`로 인가 서버를 호출한 후 다음 코드로 응답을 동기 대기했습니다.

```java
body.toFuture().get()
```

이 호출은 WebFlux 요청 처리 스레드를 차단합니다. 인가 서버의 응답이 느리거나 동시 요청이 증가하면 이벤트 루프가 고갈되어 API Gateway의 전체 응답이 지연될 수 있습니다.

###  변경 사항

- `toFuture().get()` 블로킹 호출 제거
- `WebClient.Builder`를 생성자 주입으로 변경
- 인가 응답을 리액티브 체인으로 변환
- 빈 응답을 접근 거부로 처리
- 인가 서버 통신 오류를 `AuthorizationServiceException`으로 변환
- 인가 처리 단위 테스트 4건 추가

###  해결 방법

인가 서버의 응답을 동기적으로 꺼내는 대신 `Mono` 연산자로 처리합니다.

```java
return webClientBuilder.clone()
    .baseUrl(baseUrl)
    .build()
    .get()
    .retrieve()
    .bodyToMono(Boolean.class)
    .defaultIfEmpty(false)
    .map(AuthorizationDecision::new)
    .onErrorMap(error ->
        new AuthorizationServiceException("인가 요청시 오류 발생", error)
    );
```

`WebClient.Builder`를 주입받도록 변경하여 운영 설정을 재사용하고 단위 테스트에서 통신 동작을 격리할 수 있도록 했습니다.

###  영향

- WebFlux 이벤트 루프가 인가 응답을 기다리며 차단되지 않습니다.
- 인가 서버 지연이 다른 요청에 미치는 영향을 줄입니다.
- 빈 응답은 안전하게 접근 거부로 처리됩니다.
- 통신 오류의 원인이 예외 체인에 보존됩니다.
- 기존 JWT 검증 및 refresh token 처리 방식은 유지됩니다.

###  테스트

```text
./gradlew test --tests org.egovframe.cloud.apigateway.config.ReactiveAuthorizationUnitTest
```

검증 항목:

- 인가 서버가 `true`를 반환하면 접근 허용
- 인가 서버가 `false`를 반환하면 접근 거부
- 인가 서버가 빈 응답을 반환하면 접근 거부
- 인가 서버 통신 오류를 `AuthorizationServiceException`으로 변환

테스트 결과:

```text
4 tests passed
BUILD SUCCESSFUL
```

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [x] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.
