### PR TITLE
fix(user-service): 비밀번호 재설정 토큰을 로그로 노출하지 않도록 수정 + 회귀 테스트 (CWE-532)

### DIFF
--- a/backend/user-service/src/main/java/org/egovframe/cloud/userservice/service/user/UserService.java
+++ b/backend/user-service/src/main/java/org/egovframe/cloud/userservice/service/user/UserService.java
@@ -397,7 +397,8 @@ public class UserService extends AbstractService implements UserDetailsService {
 
             userFindPasswordRepository.save(userFindPassword);
 
-            log.info("end send change password email - emailAddr: " + emailAddr + ", tokenValue: " + tokenValue);
+            // 재설정 토큰(tokenValue)은 비밀번호 재설정을 인가하는 비밀값이므로 로그로 남기지 않는다 (CWE-532).
+            log.info("end send change password email: " + emailAddr);
         } catch (MessagingException e) {
             String errorMessage = getMessage("err.user.find.password");
             log.error(errorMessage + ": " + e.getMessage());

--- a/backend/user-service/src/test/java/org/egovframe/cloud/userservice/service/user/UserServiceFindPasswordLogTest.java
+++ b/backend/user-service/src/test/java/org/egovframe/cloud/userservice/service/user/UserServiceFindPasswordLogTest.java
@@ -1,0 +1,170 @@
+package org.egovframe.cloud.userservice.service.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.egovframe.cloud.common.domain.Role;
+import org.egovframe.cloud.common.util.MessageUtil;
+import org.egovframe.cloud.userservice.api.user.dto.UserFindPasswordSaveRequestDto;
+import org.egovframe.cloud.userservice.domain.user.User;
+import org.egovframe.cloud.userservice.domain.user.UserFindPassword;
+import org.egovframe.cloud.userservice.domain.user.UserFindPasswordRepository;
+import org.egovframe.cloud.userservice.domain.user.UserRepository;
+import org.egovframe.cloud.userservice.domain.user.UserStateCode;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import jakarta.mail.internet.MimeMessage;
+
+/**
+ * org.egovframe.cloud.userservice.service.user.UserServiceFindPasswordLogTest
+ * <p>
+ * Verifies that UserService.findPassword does not expose the password reset token
+ * to the logs (CWE-532).
+ * <p>
+ * The reset token (tokenValue) is carried in changePasswordUrl(...?token=), emailed to
+ * the user and persisted in UserFindPassword. It is the secret that authorizes a
+ * password reset, so anyone able to read the log file could reset an arbitrary user's
+ * password. Therefore no log event may contain the raw token.
+ *
+ * @author EricSeokgon
+ * @version 1.0
+ */
+@ExtendWith(MockitoExtension.class)
+class UserServiceFindPasswordLogTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private UserFindPasswordRepository userFindPasswordRepository;
+
+    @Mock
+    private JavaMailSender javaMailSender;
+
+    @Mock
+    private MessageUtil messageUtil;
+
+    @InjectMocks
+    private UserService userService;
+
+    private Logger logger;
+    private ListAppender<ILoggingEvent> appender;
+
+    @BeforeEach
+    void setUp() {
+        // messageUtil is a @Resource field on AbstractService (not a constructor arg),
+        // so inject it directly.
+        ReflectionTestUtils.setField(userService, "messageUtil", messageUtil);
+
+        logger = (Logger) LoggerFactory.getLogger(UserService.class);
+        logger.setLevel(Level.DEBUG); // ensure INFO events are emitted
+        appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+    }
+
+    @AfterEach
+    void tearDown() {
+        logger.detachAppender(appender);
+    }
+
+    private UserFindPasswordSaveRequestDto requestDto(String email, String userName) {
+        UserFindPasswordSaveRequestDto dto = new UserFindPasswordSaveRequestDto();
+        ReflectionTestUtils.setField(dto, "userName", userName);
+        ReflectionTestUtils.setField(dto, "emailAddr", email);
+        ReflectionTestUtils.setField(dto, "mainUrl", "https://portal.example.org");
+        ReflectionTestUtils.setField(dto, "changePasswordUrl", "https://portal.example.org/change");
+        return dto;
+    }
+
+    private User user(String email, String userName) {
+        return User.builder()
+                .userId("uid-" + email)
+                .userName(userName)
+                .email(email)
+                .encryptedPassword("")
+                .role(Role.USER)
+                .userStateCode(UserStateCode.NORMAL.getKey())
+                .build();
+    }
+
+    @Test
+    @DisplayName("findPassword must not log the reset token (CWE-532)")
+    void findPassword_doesNotLogResetToken() {
+        // given
+        String email = "reset-target@example.com";
+        String userName = "tester";
+        when(userRepository.findByEmailAndUserName(email, userName)).thenReturn(Optional.of(user(email, userName)));
+        when(messageUtil.getMessage("email.user.password.title")).thenReturn("Password reset");
+        when(javaMailSender.createMimeMessage()).thenReturn(realMimeMessage());
+        when(userFindPasswordRepository.findNextRequestNo(email)).thenReturn(1);
+
+        // when
+        userService.findPassword(requestDto(email, userName));
+
+        // then: capture the token actually issued by the flow.
+        ArgumentCaptor<UserFindPassword> captor = ArgumentCaptor.forClass(UserFindPassword.class);
+        verify(userFindPasswordRepository).save(captor.capture());
+        String issuedToken = captor.getValue().getTokenValue();
+
+        assertThat(issuedToken)
+                .as("precondition: the reset flow must complete and issue a token")
+                .isNotBlank();
+
+        boolean tokenLeaked = appender.list.stream()
+                .map(ILoggingEvent::getFormattedMessage)
+                .anyMatch(msg -> msg.contains(issuedToken));
+
+        assertThat(tokenLeaked)
+                .as("reset token must not appear in logs (CWE-532). Captured logs: %s",
+                        appender.list.stream().map(ILoggingEvent::getFormattedMessage).toList())
+                .isFalse();
+    }
+
+    @Test
+    @DisplayName("findPassword still logs a completion marker (token omitted)")
+    void findPassword_stillLogsCompletionMarker() {
+        // given
+        String email = "reset-target@example.com";
+        String userName = "tester";
+        when(userRepository.findByEmailAndUserName(email, userName)).thenReturn(Optional.of(user(email, userName)));
+        when(messageUtil.getMessage("email.user.password.title")).thenReturn("Password reset");
+        when(javaMailSender.createMimeMessage()).thenReturn(realMimeMessage());
+        when(userFindPasswordRepository.findNextRequestNo(email)).thenReturn(1);
+
+        // when
+        userService.findPassword(requestDto(email, userName));
+
+        // then: the completion log line itself must remain for operational tracing.
+        boolean hasCompletionLog = appender.list.stream()
+                .map(ILoggingEvent::getFormattedMessage)
+                .anyMatch(msg -> msg.contains("end send change password email"));
+
+        assertThat(hasCompletionLog)
+                .as("completion marker log should be preserved")
+                .isTrue();
+    }
+
+    private MimeMessage realMimeMessage() {
+        return new JavaMailSenderImpl().createMimeMessage();
+    }
+}


### PR DESCRIPTION
## 문제 (CWE-532)

`UserService.findPassword()`가 **비밀번호 재설정 토큰을 INFO 레벨 로그로 원문 출력**합니다.

```java
final String tokenValue = UUID.randomUUID().toString().replaceAll("-", "");
final String changePasswordUrl = requestDto.getChangePasswordUrl() + "?token=" + tokenValue;
// ...
log.info("end send change password email - emailAddr: " + emailAddr + ", tokenValue: " + tokenValue);
```

`tokenValue`는 재설정 URL(`?token=`)에 실려 사용자에게 이메일로 전달되고 `UserFindPassword`로 DB에 저장되는, **비밀번호 재설정을 인가하는 비밀값**입니다. 이 값이 로그 파일에 남으면 로그 열람 권한자(운영자·로그 수집 파이프라인·SIEM 등)가 임의 사용자의 비밀번호를 재설정할 수 있습니다. INFO 레벨이라 별도 설정 없이 기본 운영 로그에 그대로 축적됩니다.

## 변경

- 완료 로그에서 토큰만 제거하고, 흐름 추적용 마커(`end send change password email: <email>`)는 유지 — 바로 위 `start send ...` 로그와 동일한 형태입니다.
- 로직 변경 없음(로그 문장 1줄).

## 검증 (TDD)

회귀 테스트 `UserServiceFindPasswordLogTest`를 추가했습니다. Logback `ListAppender`로 `findPassword` 실행 중 캡처된 모든 로그 이벤트를 수집하고, `userFindPasswordRepository.save(...)`로 실제 발급된 토큰을 `ArgumentCaptor`로 캡처해 **어떤 로그에도 그 토큰이 포함되지 않음**을 단언합니다.

- 수정 전(토큰 로그 존재): 테스트 **실패**(`tokenValue: 2eb66ec3...` 노출 확인)
- 수정 후: 테스트 **통과**
- 기존 `UserServiceTest` 회귀 없음, `./gradlew test --tests *UserServiceFindPasswordLogTest` 그린
- 두 번째 테스트로 완료 로그 마커가 유지됨도 함께 검증

## 참고

- 같은 클래스의 `log.info("loadUserByUsername! email={}", email)` 등 이메일 로깅은 기존 관례라 이 PR 범위에서 제외했습니다. 정책상 정비가 필요하면 후속 PR로 제안하겠습니다.