### PR TITLE
fix: user-service 테스트 H2 설정이 예약어와 옛 속성명 때문에 동작하지 않는 문제 수정

### DIFF
--- a/backend/user-service/src/test/resources/application-test.yml
+++ b/backend/user-service/src/test/resources/application-test.yml
@@ -7,9 +7,11 @@ spring:
     username: sa
     password: 
     driver-class-name: org.h2.Driver
-    initialization-mode: always
-#    schema: classpath:h2/schema.sql
-    data: classpath:h2/data.sql
+  sql:
+    init:
+      mode: always
+#      schema-locations: classpath:h2/schema.sql
+      data-locations: classpath:h2/data.sql
   jpa:
     hibernate:
       generate-ddl: true
@@ -19,6 +21,8 @@ spring:
       hibernate:
         format_sql: true
         default_batch_fetch_size: 1000
+        auto_quote_keyword: true
+    defer-datasource-initialization: true
     show-sql: true
   h2:
     console:


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`user-service` 테스트가 56건 중 30건 실패하고, 그중 28건이 `InvalidDataAccessResourceUsageException: could not prepare statement [Syntax error ...]` 입니다. 원인이 두 겹입니다.

**첫째, 테이블명이 H2 2.x 예약어입니다.** 엔티티에 `@Table` 선언이 없어 테이블명이 클래스명에서 유도되는데 `User` 는 `user`, `Authorization` 은 `authorization` 이 되고 이 둘은 H2 2.x 에서 예약어입니다. `com.h2database:h2` 버전이 고정돼 있지 않아 Boot 3.x BOM 이 2.3.232 를 가져오며, 예약어가 아니던 1.4.x 시절에는 문제가 되지 않았습니다. Hibernate 의 `halt_on_error` 기본값이 `false` 라 DDL 실패가 경고로 넘어가고, 테이블이 없는 상태로 컨텍스트가 뜬 뒤 런타임 질의에서 같은 예약어에 걸립니다. `hibernate.auto_quote_keyword` 를 켜서 예약어를 자동 인용하도록 했습니다.

H2 접속 URL 의 `MODE` 는 이 문제와 무관합니다. `MODE=MYSQL`, `MODE` 없음, `MODE=LEGACY` 세 경우 모두 같은 오류가 납니다.

**둘째, 스크립트 초기화 속성명이 Boot 2.5 이전 형태입니다.** `spring.datasource.initialization-mode` 와 `spring.datasource.data` 는 Boot 2.5 에서 `spring.sql.init` 하위로 이동했고 현재는 바인딩되지 않고 무시됩니다. 그래서 `h2/data.sql` 이 실행되지 않아 시드 데이터가 들어가지 않습니다. 속성명을 `spring.sql.init.mode` 와 `spring.sql.init.data-locations` 로 옮겼습니다.

**두 겹은 순서에 의존합니다.** 속성명만 옮기고 예약어를 그대로 두면 존재하지 않는 테이블에 INSERT 하게 되어 오히려 나빠집니다. 그리고 스크립트 초기화가 기본적으로 JPA 초기화보다 먼저 실행되므로 `spring.jpa.defer-datasource-initialization` 이 필요합니다. 이 한 줄만 빼고 측정하면 `ApplicationContext failure` 32건이 발생해 실패가 34건으로 늘어납니다.

변경은 `backend/user-service/src/test/resources/application-test.yml` 한 파일이며 운영 설정과 `src/main` 은 건드리지 않았습니다.

```yaml
  sql:
    init:
      mode: always
      data-locations: classpath:h2/data.sql
  jpa:
    properties:
      hibernate:
        auto_quote_keyword: true
    defer-datasource-initialization: true
```

`board-service` 와 `portal-service` 도 같은 예약어 조건을 갖고 있으나 이 PR 범위에서 제외했습니다. `board-service` 를 측정해 보니 실패 27건 중 25건이 `UnknownContentTypeException` 으로 서비스 간 인가 호출 응답에서 오는 다른 층이 지배 원인이었고, 예약어를 인용해도 결과가 달라지는지 확인하지 못했습니다. 근거 없이 같은 수정을 확산하지 않고 별건으로 두었습니다.

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

측정 환경은 JDK 21, 저장소의 Gradle 8.5 wrapper 입니다. 테스트 리소스를 바꿔 측정할 때 Gradle 파일 감시가 `processTestResources` 를 건너뛰는 경우가 있어 `--no-watch-fs` 로 실행했습니다.

```
./gradlew test --no-watch-fs
```

| 조건 | 전체 | 실패 | 통과 | skipped |
| --- | --- | --- | --- | --- |
| 수정 전 | 56 | 30 | 25 | 1 |
| 수정 후 | 56 | **7** | **48** | 1 |
| 참고: `defer-datasource-initialization` 만 제외 | 56 | 34 | 22 | 0 |

예약어 문법 오류 28건이 0건이 되고 통과가 23건 늘었습니다. 수정 전 값은 두 번 측정해 동일한 결과를 확인했습니다.

남은 실패 7건은 전부 수정 전에도 실패하던 클래스 안에 있으며, 새로 실패하는 클래스는 없습니다. 원인은 인가 응답 기대값(400 대 401), 응답 콘텐츠 타입, 메시지 외부화 등 이 변경과 다른 층이라 이 PR 에서 다루지 않았습니다.

| 클래스 | 수정 전 실패 | 수정 후 실패 |
| --- | --- | --- |
| `AuthorizationApiControllerTest` | 7 | 0 |
| `RoleApiControllerTest` | 2 | 0 |
| `RoleAuthorizationApiControllerTest` | 3 | 1 |
| `UserApiControllerTest` | 17 | 5 |
| `MessageSourceConfigTest` | 1 | 1 (이 변경과 무관) |

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

테스트 설정 파일 변경이라 화면 동작과 무관하여 브라우저 테스트는 진행하지 않았습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면 변경이 없어 스크린샷을 첨부하지 않았습니다. 대신 수정 전후 실패 서명 변화를 정리했습니다.

수정 전 실패 30건의 서명 분포

```
 28  org.springframework.dao.InvalidDataAccessResourceUsageException: could not prepare statement [Syntax ...]
  1  org.opentest4j.AssertionFailedError: Expecting value to be true but was false
  1  org.opentest4j.AssertionFailedError: expected: "로그인" but was: "common.login..."
```

수정 후 실패 7건의 서명 분포

```
  3  java.lang.AssertionError: Response status expected:<400> but was:<401>
  1  java.lang.AssertionError: Content type not set
  1  org.opentest4j.AssertionFailedError: Expected RestClientException to be thrown
  1  org.springframework.dao.DataIntegrityViolationException: JDBC exception executing SQL [select ...]
  1  org.opentest4j.AssertionFailedError: expected: "로그인" but was: "common.login..."
```
