### PR TITLE
fix(user-service): refresh token 재발급 요청이 NullPointerException으로 실패하는 문제 수정

### DIFF
--- a/backend/user-service/src/main/java/org/egovframe/cloud/userservice/config/AuthenticationFilter.java
+++ b/backend/user-service/src/main/java/org/egovframe/cloud/userservice/config/AuthenticationFilter.java
@@ -201,12 +201,14 @@ public class AuthenticationFilter extends UsernamePasswordAuthenticationFilter {
 
                 String username = claims.getSubject();
                 if (username == null) {
-                    // refresh token 에는 subject, authorities 정보가 없다.
                     SecurityContextHolder.getContext().setAuthentication(null);
                 } else {
-                    List<SimpleGrantedAuthority> roleList = Arrays.stream(claims.get(tokenProvider.TOKEN_CLAIM_NAME, String.class).split(","))
-                            .map(SimpleGrantedAuthority::new)
-                            .collect(Collectors.toList());
+                    // refresh token 에는 authorities 정보가 없다.
+                    String authoritiesStr = claims.get(tokenProvider.TOKEN_CLAIM_NAME, String.class);
+                    List<SimpleGrantedAuthority> roleList = authoritiesStr == null ? List.of() :
+                            Arrays.stream(authoritiesStr.split(","))
+                                    .map(SimpleGrantedAuthority::new)
+                                    .collect(Collectors.toList());
                     SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(username, null, roleList));
                 }
 

--- a/backend/user-service/src/test/java/org/egovframe/cloud/userservice/config/AuthenticationFilterRefreshTokenTest.java
+++ b/backend/user-service/src/test/java/org/egovframe/cloud/userservice/config/AuthenticationFilterRefreshTokenTest.java
@@ -1,0 +1,119 @@
+package org.egovframe.cloud.userservice.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+
+import org.egovframe.cloud.userservice.api.user.dto.UserResponseDto;
+import org.egovframe.cloud.userservice.service.user.UserService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * refresh token 으로 들어온 요청을 AuthenticationFilter 가 처리하는 경로의 회귀 테스트.
+ *
+ * refresh token 에는 authorities 클레임이 없다(TokenProvider.createRefreshToken).
+ * 같은 저장소의 나머지 AuthenticationFilter 세 곳(module-common, board-service,
+ * portal-service)은 authorities 가 없을 수 있다고 보고 null 을 빈 목록으로 처리한다.
+ */
+class AuthenticationFilterRefreshTokenTest {
+
+    private static final String SECRET = "egovframe_user_token";
+    private static final String USER_ID = "USER_0000000000000000001";
+    private static final String EMAIL = "test@egovframe.org";
+
+    private UserService userService;
+    private TokenProvider tokenProvider;
+    private AuthenticationFilter filter;
+
+    @BeforeEach
+    void setUp() {
+        userService = mock(UserService.class);
+        tokenProvider = new TokenProvider(userService);
+        ReflectionTestUtils.setField(tokenProvider, "TOKEN_SECRET", SECRET);
+        ReflectionTestUtils.setField(tokenProvider, "TOKEN_EXPIRATION_TIME", "3600000");
+        ReflectionTestUtils.setField(tokenProvider, "TOKEN_REFRESH_TIME", "86400000");
+        filter = new AuthenticationFilter(mock(AuthenticationManager.class), tokenProvider, userService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    /**
+     * 로그인 성공 시 애플리케이션이 실제로 발급하는 refresh token 을 그대로 얻는다.
+     */
+    private String issuedRefreshToken() {
+        UserResponseDto userResponseDto = mock(UserResponseDto.class);
+        when(userResponseDto.getUserId()).thenReturn(USER_ID);
+        when(userService.findByEmail(anyString())).thenReturn(userResponseDto);
+
+        Authentication authResult = new UsernamePasswordAuthenticationToken(
+                EMAIL, null, Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER")));
+
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        tokenProvider.createTokenAndAddHeader(
+                new MockHttpServletRequest(), response, new MockFilterChain(), authResult);
+
+        return response.getHeader("refresh-token");
+    }
+
+    @Test
+    @DisplayName("발급된 refresh token 에는 authorities 클레임이 없다")
+    void refreshTokenHasNoAuthoritiesClaim() {
+        String refreshToken = issuedRefreshToken();
+
+        assertThat(refreshToken).isNotNull();
+        assertThat(tokenProvider.getClaimsFromToken(refreshToken).getSubject()).isEqualTo(USER_ID);
+        assertThat(tokenProvider.getClaimsFromToken(refreshToken)
+                .get(tokenProvider.TOKEN_CLAIM_NAME, String.class)).isNull();
+    }
+
+    @Test
+    @DisplayName("refresh token 재발급 요청이 필터를 통과한다")
+    void refreshTokenRequestPassesThroughFilter() {
+        String refreshToken = issuedRefreshToken();
+
+        MockHttpServletRequest request = new MockHttpServletRequest("PUT", "/api/v1/users/token/refresh");
+        request.addHeader(HttpHeaders.AUTHORIZATION, refreshToken);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        assertThatCode(() -> filter.doFilter(request, response, chain)).doesNotThrowAnyException();
+        assertThat(chain.getRequest())
+                .as("필터가 재발급 요청을 컨트롤러로 넘겨야 한다")
+                .isNotNull();
+    }
+
+    @Test
+    @DisplayName("권한이 없는 refresh token 은 빈 권한으로 처리한다")
+    void refreshTokenGrantsNoAuthorities() {
+        String refreshToken = issuedRefreshToken();
+
+        MockHttpServletRequest request = new MockHttpServletRequest("PUT", "/api/v1/users/token/refresh");
+        request.addHeader(HttpHeaders.AUTHORIZATION, refreshToken);
+
+        filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertThat(authentication).isNotNull();
+        assertThat(authentication.getAuthorities()).isEmpty();
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`AuthenticationFilter`는 subject가 있으면 `authorities` 클레임도 있다고 보고 널 검사 없이 `split(",")`을 호출합니다.

```java
String username = claims.getSubject();
if (username == null) {
    // refresh token 에는 subject, authorities 정보가 없다.
    SecurityContextHolder.getContext().setAuthentication(null);
} else {
    List<SimpleGrantedAuthority> roleList = Arrays.stream(claims.get(tokenProvider.TOKEN_CLAIM_NAME, String.class).split(","))
```

그런데 `TokenProvider.createRefreshToken`은 subject만 넣고 `authorities`는 넣지 않습니다(`createAccessToken`에만 `.claim(TOKEN_CLAIM_NAME, ...)`이 있습니다). 그래서 refresh token으로 들어온 요청은 위 주석과 달리 subject가 있어 `else`로 흘러가고, `claims.get(...)`이 null을 돌려주면서 `NullPointerException`이 납니다.

이 예외는 `doFilter`의 catch 세 곳(`BusinessException`·`JwtException`·`ServletException | IOException`) 어디에도 걸리지 않아 필터 밖으로 전파됩니다. 재발급 컨트롤러는 실행되지 않습니다.

같은 저장소의 나머지 `AuthenticationFilter` 세 곳은 `authorities`가 없을 수 있다고 보고 처리합니다.

```java
// egovframe-cloud-module-common:82, board-service:73, portal-service:73
String authoritiesStr = claims.get(TOKEN_CLAIM_NAME, String.class);
List<SimpleGrantedAuthority> roleList = authoritiesStr == null ? List.of() : ...
```

AS-IS / TO-BE

```diff
-                    List<SimpleGrantedAuthority> roleList = Arrays.stream(claims.get(tokenProvider.TOKEN_CLAIM_NAME, String.class).split(","))
-                            .map(SimpleGrantedAuthority::new)
-                            .collect(Collectors.toList());
+                    String authoritiesStr = claims.get(tokenProvider.TOKEN_CLAIM_NAME, String.class);
+                    List<SimpleGrantedAuthority> roleList = authoritiesStr == null ? List.of() :
+                            Arrays.stream(authoritiesStr.split(","))
+                                    .map(SimpleGrantedAuthority::new)
+                                    .collect(Collectors.toList());
```

username이 null이면 인증을 비우고 요청을 그대로 넘기는 이 필터 고유의 흐름은 바꾸지 않았습니다. 형제 필터는 그 경우 401을 돌려주지만, 재발급 엔드포인트는 통과시켜야 하므로 `authorities` 널 처리만 맞췄습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

`createTokenAndAddHeader`로 로그인 시 실제 발급되는 refresh token을 받아 그대로 필터에 넣습니다.

수정 전(RED)

```
java.lang.NullPointerException at AuthenticationFilterRefreshTokenTest.java:113
3 tests completed, 2 failed
```

수정 후(GREEN)

```
BUILD SUCCESSFUL
```

`user-service` 전체 스위트는 이 변경 전후가 같습니다 — 59건 중 30건 실패이고, 실패 클래스와 건수(`AuthorizationApiControllerTest` 7/7, `MessageSourceConfigTest` 1/1, `RoleApiControllerTest` 2/2, `RoleAuthorizationApiControllerTest` 3/4, `UserApiControllerTest` 17/19)가 변경 전 `main`과 동일합니다.

## 테스트 브라우저 Test Browser

서버측 필터 수정이라 브라우저와 무관합니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면 변경이 없어 첨부하지 않았습니다.
