### PR TITLE
fix(reserve-item-service): 사용여부 없이 물품 목록을 조회하면 NullPointerException이 나는 문제 수정

### DIFF
--- a/backend/reserve-item-service/src/main/java/org/egovframe/cloud/reserveitemservice/api/reserveItem/dto/ReserveItemRequestDto.java
+++ b/backend/reserve-item-service/src/main/java/org/egovframe/cloud/reserveitemservice/api/reserveItem/dto/ReserveItemRequestDto.java
@@ -48,6 +48,10 @@ public class ReserveItemRequestDto extends RequestDto {
         return Objects.nonNull(id) && !Objects.equals("null", id) && !Objects.equals("undefined", id);
     }
 
+    public boolean isUse() {
+        return Boolean.TRUE.equals(isUse);
+    }
+
     public boolean isPopup() {
         return Boolean.TRUE.equals(isPopup);
     }

--- a/backend/reserve-item-service/src/main/java/org/egovframe/cloud/reserveitemservice/domain/reserveItem/ReserveItemRepositoryImpl.java
+++ b/backend/reserve-item-service/src/main/java/org/egovframe/cloud/reserveitemservice/domain/reserveItem/ReserveItemRepositoryImpl.java
@@ -233,7 +233,7 @@ public class ReserveItemRepositoryImpl implements ReserveItemRepositoryCustom{
             whereCriteria.add(where("category_id").in(requestDto.getCategoryId()));
         }
 
-        if (requestDto.getIsUse()) {
+        if (requestDto.isUse()) {
             whereCriteria.add(where("use_at").isTrue());
         }
 

--- a/backend/reserve-item-service/src/test/java/org/egovframe/cloud/reserveitemservice/domain/reserveItem/ReserveItemRepositoryImplSearchParamTest.java
+++ b/backend/reserve-item-service/src/test/java/org/egovframe/cloud/reserveitemservice/domain/reserveItem/ReserveItemRepositoryImplSearchParamTest.java
@@ -1,0 +1,81 @@
+package org.egovframe.cloud.reserveitemservice.domain.reserveItem;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import java.util.List;
+
+import org.egovframe.cloud.reserveitemservice.api.reserveItem.dto.ReserveItemRequestDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.relational.core.query.Criteria;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * org.egovframe.cloud.reserveitemservice.domain.reserveItem.ReserveItemRepositoryImplSearchParamTest
+ * <p>
+ * 예약 물품 목록 검색조건 조립 단위 테스트
+ *
+ * @author 표준프레임워크센터
+ * @version 1.0
+ * @since 2026/08/28
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *     수정일        수정자           수정내용
+ *  ----------    --------    ---------------------------
+ *  2026/08/28    contributors  최초 생성
+ * </pre>
+ */
+class ReserveItemRepositoryImplSearchParamTest {
+
+    private final ReserveItemRepositoryImpl repository = new ReserveItemRepositoryImpl(null);
+
+    @SuppressWarnings("unchecked")
+    private List<Criteria> whereQuery(ReserveItemRequestDto requestDto) {
+        return (List<Criteria>) ReflectionTestUtils.invokeMethod(repository, "whereQuery", requestDto);
+    }
+
+    @DisplayName("isUse 를 보내지 않아도 검색조건을 만들 수 있다")
+    @Test
+    void whereQuery_without_isUse() {
+        ReserveItemRequestDto requestDto = new ReserveItemRequestDto();
+
+        assertThatCode(() -> whereQuery(requestDto)).doesNotThrowAnyException();
+        assertThat(whereQuery(requestDto)).isEmpty();
+    }
+
+    @DisplayName("isUse 가 true 이면 사용여부 조건이 붙는다")
+    @Test
+    void whereQuery_with_isUse_true() {
+        ReserveItemRequestDto requestDto = new ReserveItemRequestDto();
+        requestDto.setIsUse(true);
+
+        assertThat(whereQuery(requestDto))
+                .singleElement()
+                .satisfies(criteria -> assertThat(criteria.toString()).contains("use_at"));
+    }
+
+    @DisplayName("isUse 가 false 이면 사용여부 조건이 붙지 않는다")
+    @Test
+    void whereQuery_with_isUse_false() {
+        ReserveItemRequestDto requestDto = new ReserveItemRequestDto();
+        requestDto.setIsUse(false);
+
+        assertThat(whereQuery(requestDto)).isEmpty();
+    }
+
+    @DisplayName("isUse 와 isPopup 이 함께 오면 두 조건이 붙는다")
+    @Test
+    void whereQuery_with_isUse_and_isPopup() {
+        ReserveItemRequestDto requestDto = new ReserveItemRequestDto();
+        requestDto.setIsUse(true);
+        requestDto.setIsPopup(true);
+
+        assertThat(whereQuery(requestDto))
+                .hasSize(2)
+                .anySatisfy(criteria -> assertThat(criteria.toString()).contains("use_at"))
+                .anySatisfy(criteria -> assertThat(criteria.toString()).contains("reserve_method_id"));
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`ReserveItemRepositoryImpl.whereQuery`는 검색조건 다섯 개를 조립합니다. 키워드 조건을 뺀 넷 가운데 셋은 `ReserveItemRequestDto`의 널 안전 접근자를 거치는데 `isUse`만 `Boolean`을 그대로 언박싱합니다.

```java
if (requestDto.hasLocationId()) {   // hasId(locationId)
if (requestDto.hasCategoryId()) {   // hasId(categoryId)
if (requestDto.getIsUse()) {        // Boolean 언박싱
if (requestDto.isPopup()) {         // Boolean.TRUE.equals(isPopup)
```

네 값 모두 선택 파라미터라 요청에 없으면 null입니다. 컨트롤러도 이 값들에 필수 제약을 두지 않습니다. `isUse`를 빼고 목록을 조회하면 `NullPointerException: Cannot invoke "java.lang.Boolean.booleanValue()"`가 납니다. 관리자 화면은 이 값을 항상 실어 보내므로 화면으로는 재현되지 않고, API를 직접 호출할 때 드러납니다.

같은 DTO에 `isPopup()`이 이미 같은 문제를 푸는 형태로 있어 그대로 맞췄습니다.

AS-IS / TO-BE

```diff
// ReserveItemRequestDto
+    public boolean isUse() {
+        return Boolean.TRUE.equals(isUse);
+    }
+
     public boolean isPopup() {
         return Boolean.TRUE.equals(isPopup);
     }
```

```diff
// ReserveItemRepositoryImpl.whereQuery
-        if (requestDto.getIsUse()) {
+        if (requestDto.isUse()) {
```

`isUse`가 `false`일 때 조건을 붙이지 않는 기존 동작은 그대로입니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

`whereQuery`가 만드는 조건 목록을 직접 확인합니다. 네 케이스는 isUse 없음 / true / false / isUse와 isPopup 동시 지정입니다.

수정 전(RED)

```
java.lang.AssertionError: Expecting code not to raise a throwable but caught
  "java.lang.NullPointerException: Cannot invoke "java.lang.Boolean.booleanValue()"
   because the return value of "...ReserveItemRequestDto.getIsUse()" is null"
4 tests completed, 1 failed
```

수정 후(GREEN)

```
BUILD SUCCESSFUL
```

`reserve-item-service` 전체 스위트는 이 변경 전후가 같습니다 — 16건 실패이고, 실패 클래스와 건수(`LocationApiControllerTest` 7/7, `ReserveItemApiControllerTest` 8/8, `ReserveItemServiceApplicationTests` 1/1)가 변경 전 `main`과 동일합니다.

## 테스트 브라우저 Test Browser

서버측 조회조건 수정이라 브라우저와 무관합니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면 변경이 없어 첨부하지 않았습니다.
