### PR TITLE
fix(portal-service): 공통코드·공통코드 상세 수정에서 필수값 검증이 실행되지 않는 문제 수정

### DIFF
--- a/backend/portal-service/src/main/java/org/egovframe/cloud/portalservice/api/code/CodeApiController.java
+++ b/backend/portal-service/src/main/java/org/egovframe/cloud/portalservice/api/code/CodeApiController.java
@@ -107,7 +107,7 @@ public class CodeApiController {
      */
     @PreAuthorize("hasRole('ADMIN')")
     @PutMapping("/api/v1/codes/{codeId}")
-    public String update(@PathVariable("codeId") String codeId, @RequestBody CodeUpdateRequestDto requestDto) {
+    public String update(@PathVariable("codeId") String codeId, @RequestBody @Valid CodeUpdateRequestDto requestDto) {
         return codeService.update(codeId, requestDto);
     }
 

--- a/backend/portal-service/src/main/java/org/egovframe/cloud/portalservice/api/code/CodeDetailApiController.java
+++ b/backend/portal-service/src/main/java/org/egovframe/cloud/portalservice/api/code/CodeDetailApiController.java
@@ -133,7 +133,7 @@ public class CodeDetailApiController {
      */
     @PreAuthorize("hasRole('ADMIN')")
     @PutMapping("/api/v1/code-details/{codeId}")
-    public String update(@PathVariable("codeId") String codeId, @RequestBody CodeDetailUpdateRequestDto requestDto) {
+    public String update(@PathVariable("codeId") String codeId, @RequestBody @Valid CodeDetailUpdateRequestDto requestDto) {
         return codeDetailService.update(codeId, requestDto);
     }
 

--- a/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/api/code/CodeApiControllerValidationTest.java
+++ b/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/api/code/CodeApiControllerValidationTest.java
@@ -1,0 +1,61 @@
+package org.egovframe.cloud.portalservice.api.code;
+
+import static org.mockito.Mockito.mock;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.egovframe.cloud.portalservice.domain.code.CodeRepository;
+import org.egovframe.cloud.portalservice.service.code.CodeService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+/**
+ * org.egovframe.cloud.portalservice.api.code.CodeApiControllerValidationTest
+ * <p>
+ * 공통코드 수정 요청 검증 단위 테스트
+ *
+ * @author 표준프레임워크센터
+ * @version 1.0
+ * @since 2026/08/28
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *     수정일        수정자           수정내용
+ *  ----------    --------    ---------------------------
+ *  2026/08/28    contributors  최초 생성
+ * </pre>
+ */
+class CodeApiControllerValidationTest {
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new CodeApiController(mock(CodeService.class), mock(CodeRepository.class)))
+                .build();
+    }
+
+    @DisplayName("코드 명이 비어 있으면 수정 요청이 거부된다")
+    @Test
+    void update_rejects_blank_code_name() throws Exception {
+        mockMvc.perform(put("/api/v1/codes/{codeId}", "TEST_CODE")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"codeId\":\"TEST_CODE\",\"codeName\":\"  \"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @DisplayName("코드 명이 있으면 수정 요청이 통과한다")
+    @Test
+    void update_accepts_code_name() throws Exception {
+        mockMvc.perform(put("/api/v1/codes/{codeId}", "TEST_CODE")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"codeId\":\"TEST_CODE\",\"codeName\":\"테스트 코드\"}"))
+                .andExpect(status().isOk());
+    }
+}

--- a/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/api/code/CodeDetailApiControllerValidationTest.java
+++ b/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/api/code/CodeDetailApiControllerValidationTest.java
@@ -1,0 +1,70 @@
+package org.egovframe.cloud.portalservice.api.code;
+
+import static org.mockito.Mockito.mock;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.egovframe.cloud.portalservice.domain.code.CodeRepository;
+import org.egovframe.cloud.portalservice.service.code.CodeDetailService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+/**
+ * org.egovframe.cloud.portalservice.api.code.CodeDetailApiControllerValidationTest
+ * <p>
+ * 공통코드 상세 수정 요청 검증 단위 테스트
+ *
+ * @author 표준프레임워크센터
+ * @version 1.0
+ * @since 2026/08/28
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *     수정일        수정자           수정내용
+ *  ----------    --------    ---------------------------
+ *  2026/08/28    contributors  최초 생성
+ * </pre>
+ */
+class CodeDetailApiControllerValidationTest {
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new CodeDetailApiController(mock(CodeDetailService.class), mock(CodeRepository.class)))
+                .build();
+    }
+
+    @DisplayName("상위 코드ID 가 비어 있으면 수정 요청이 거부된다")
+    @Test
+    void update_rejects_blank_parent_code_id() throws Exception {
+        mockMvc.perform(put("/api/v1/code-details/{codeId}", "TEST_DETAIL")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"parentCodeId\":\"\",\"codeName\":\"테스트 코드\"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @DisplayName("코드 명이 비어 있으면 수정 요청이 거부된다")
+    @Test
+    void update_rejects_blank_code_name() throws Exception {
+        mockMvc.perform(put("/api/v1/code-details/{codeId}", "TEST_DETAIL")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"parentCodeId\":\"TEST_CODE\",\"codeName\":\"  \"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @DisplayName("필수 값이 모두 있으면 수정 요청이 통과한다")
+    @Test
+    void update_accepts_required_values() throws Exception {
+        mockMvc.perform(put("/api/v1/code-details/{codeId}", "TEST_DETAIL")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"parentCodeId\":\"TEST_CODE\",\"codeName\":\"테스트 코드\"}"))
+                .andExpect(status().isOk());
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`CodeUpdateRequestDto`와 `CodeDetailUpdateRequestDto`는 i18n 메시지를 단 `@NotBlank`를 선언합니다.

```java
// CodeUpdateRequestDto
@NotBlank(message = "{code.code_id}{valid.required}")
private String codeId;
@NotBlank(message = "{code.code_name}{valid.required}")
private String codeName;
```

그런데 두 컨트롤러의 수정 핸들러에는 `@Valid`가 없어 이 제약이 한 번도 실행되지 않습니다. 같은 컨트롤러의 등록 핸들러에는 있습니다.

```java
public String save(@RequestBody @Valid CodeSaveRequestDto requestDto) {
public String update(@PathVariable("codeId") String codeId, @RequestBody CodeUpdateRequestDto requestDto) {
```

`portal-service`에서 수정용 DTO에 제약을 선언한 것은 여섯이고, 그중 `banner`·`content`·`privacy` 셋은 수정 핸들러에도 `@Valid`가 있습니다. 제약을 선언하지 않은 `attachment`·`policy`는 `@Valid`도 없어 일관적입니다. `code`·`code-detail`만 제약을 선언해 놓고 실행하지 않습니다.

`CodeService.update`는 조회한 결과에 요청 값을 그대로 넘기므로 서비스 계층에서 걸러지지도 않습니다.

```java
Code code = codeRepository.findByCodeId(codeId)
        .orElseThrow(() -> new EntityNotFoundException(...));

code.update(requestDto.getCodeName(), requestDto.getCodeDescription(), requestDto.getSortSeq(), requestDto.getUseAt());
```

AS-IS / TO-BE

```diff
-    public String update(@PathVariable("codeId") String codeId, @RequestBody CodeUpdateRequestDto requestDto) {
+    public String update(@PathVariable("codeId") String codeId, @RequestBody @Valid CodeUpdateRequestDto requestDto) {
```

```diff
-    public String update(@PathVariable("codeId") String codeId, @RequestBody CodeDetailUpdateRequestDto requestDto) {
+    public String update(@PathVariable("codeId") String codeId, @RequestBody @Valid CodeDetailUpdateRequestDto requestDto) {
```

`ExceptionHandlerAdvice`가 `MethodArgumentNotValidException`을 400과 i18n 메시지로 이미 처리하므로 등록과 같은 응답이 나갑니다.

관리자 화면은 수정 요청에 `codeId`와 `codeName`을 모두 실어 보내므로 화면 동작은 바뀌지 않습니다. 다만 기존 통합 테스트 `CodeApiControllerTest.공통코드_수정된다`는 `codeId` 없이 DTO를 만들어 보내므로, 그 테스트가 실행되는 환경에서는 `codeId`를 채워야 합니다.

### 범위

`menu`도 수정용 DTO에 `@NotBlank`가 있고 `@Valid`가 없습니다. 다만 `MenuService.update`는 `validateUpdate` 훅을 따로 갖고 있어 성격이 달라 이번 범위에서 뺐습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

관리자 화면은 클라이언트에서 필수 입력을 막으므로, 검증이 서버에 도달하는지를 보기 위해 컨트롤러에 직접 요청을 보냅니다.

수정 전(RED)

```
CodeApiControllerValidationTest > 코드 명이 비어 있으면 수정 요청이 거부된다 FAILED
2 tests completed, 1 failed
```

수정 후(GREEN)

```
BUILD SUCCESSFUL
```

`portal-service` 전체 스위트는 이 변경 전후가 같습니다 — 70건 실패이고 실패 클래스와 건수가 변경 전 `main`과 동일합니다.

## 테스트 브라우저 Test Browser

서버측 요청 검증 수정이라 브라우저와 무관합니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면 변경이 없어 첨부하지 않았습니다.
