### PR TITLE
ci(frontend): 프론트엔드 빌드가 Node 17 이상에서 실패하는 문제 수정

### DIFF
--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -35,4 +35,8 @@ jobs:
         run: cd frontend/${{ matrix.app }} && npm ci
 
       - name: Build ${{ matrix.app }}
+        # Next.js 11 의 webpack 이 MD4 해시를 쓰는데 OpenSSL 3(Node 17+)에는 없다.
+        # 두 앱의 package.json engines 와 Dockerfile 은 node 14.8.0 을 선언한다.
+        env:
+          NODE_OPTIONS: --openssl-legacy-provider
         run: cd frontend/${{ matrix.app }} && npm run build --if-present


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`Frontend Build` 워크플로는 2026-08-21에 추가된 뒤 성공한 실행이 없습니다. 실행 이력에 기록된 결과는 전부 실패이고(161건), `main` 브랜치의 최근 실행도 마찬가지입니다.

두 앱 모두 같은 지점에서 멈춥니다.

```
Error: error:0308010C:digital envelope routines::unsupported
    at BulkUpdateDecorator.hashFactory (node_modules/next/dist/compiled/webpack/bundle5.js)
  code: 'ERR_OSSL_EVP_UNSUPPORTED'
```

Next.js 11의 webpack은 청크 해시에 MD4를 씁니다. OpenSSL 3은 MD4를 기본 제공하지 않으므로 Node 17 이상에서는 빌드가 중단됩니다.

프로젝트가 선언하는 Node 버전은 14.8.0입니다.

```json
// frontend/portal/package.json, frontend/admin/package.json
"engines": { "node": "14.8.0", "npm": "6.14.7" }
```

```dockerfile
# frontend/portal/Dockerfile, frontend/admin/Dockerfile
FROM node:14.8.0-alpine
```

`README.md:183`도 `node : 14.8.0`으로 적혀 있습니다. 워크플로만 `node-version: '22'`입니다.

AS-IS / TO-BE

```diff
       - name: Build ${{ matrix.app }}
+        env:
+          NODE_OPTIONS: --openssl-legacy-provider
         run: cd frontend/${{ matrix.app }} && npm run build --if-present
```

워크플로가 고른 Node 22를 그대로 두고 MD4만 쓸 수 있게 했습니다. Node를 14.8.0으로 내리면 선언과는 맞지만 지원이 끝난 버전을 CI에 설치하게 되어 택하지 않았습니다.

### 범위

`.eslintrc.js`가 `eslint-config-prettier` 8.0에서 제거된 `prettier/@typescript-eslint`·`prettier/react`를 계속 참조해 빌드 로그에 오류가 찍히는 문제가 따로 있습니다. 다만 그 오류는 빌드를 중단시키지 않고 린트 단계만 건너뛰게 하므로 이번 범위에서 뺐습니다.

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

두 앱을 로컬에서 `npm ci` 후 빌드해 확인했습니다.

수정 전

```
$ npm run build
Error: error:0308010C:digital envelope routines::unsupported
  code: 'ERR_OSSL_EVP_UNSUPPORTED'
```

수정 후

```
$ NODE_OPTIONS=--openssl-legacy-provider npm run build
+ First Load JS shared by all        183 kB
  ├ chunks/framework.2191d1.js       42.4 kB
  ├ chunks/main.4f854d.js            28 kB
```

`admin`은 `build:next` 다음의 `build:server`(tsc)까지 마치고 `.next`와 `dist`가 생성됩니다. 이 PR의 워크플로 실행 결과가 그대로 확인 근거가 됩니다.

## 테스트 브라우저 Test Browser

빌드 설정 수정이라 브라우저와 무관합니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면 변경이 없어 첨부하지 않았습니다.
