### PR TITLE
fix(portal-service): 배너 정렬 순서 수정이 반영되지 않는 문제 수정

### DIFF
--- a/backend/portal-service/src/main/java/org/egovframe/cloud/portalservice/service/banner/BannerService.java
+++ b/backend/portal-service/src/main/java/org/egovframe/cloud/portalservice/service/banner/BannerService.java
@@ -162,11 +162,8 @@ public class BannerService extends AbstractService {
             .orElseThrow(() ->
                 new EntityNotFoundException(getMessage("valid.notexists.format", new Object[]{getMessage("menu.site")}) + " ID= " + requestDto.getSiteId()));
 
-        // 동일한 정렬 순서가 존재할 경우 +1
-        Optional<Banner> authorization = bannerRepository.findBySortSeqAndSiteId(requestDto.getSortSeq(), requestDto.getSiteId());
-        if (authorization.isPresent()) {
-            bannerRepository.updateSortSeq(requestDto.getSortSeq(), null, 1, requestDto.getSiteId());
-        }
+        // 정렬 순서가 변경된 경우 사이 구간 정렬 순서 조정
+        updateSortSeq(entity, requestDto);
 
         // 수정
         entity.update(requestDto.getBannerTypeCode(), requestDto.getBannerTitle(), requestDto.getAttachmentCode(),
@@ -203,6 +200,37 @@ public class BannerService extends AbstractService {
 
         // 삭제
         bannerRepository.delete(entity);
+    }
+
+    /**
+     * 정렬 순서 변경에 따라 사이 구간의 정렬 순서를 조정한다
+     *
+     * @param entity     배너 엔티티
+     * @param requestDto 배너 수정 요청 DTO
+     */
+    private void updateSortSeq(Banner entity, BannerUpdateRequestDto requestDto) {
+        Integer beforeSortSeq = entity.getSortSeq();
+        Integer afterSortSeq = requestDto.getSortSeq();
+
+        if (beforeSortSeq == null) {
+            bannerRepository.updateSortSeq(afterSortSeq, null, 1, requestDto.getSiteId());
+            return;
+        }
+
+        if (afterSortSeq == null) {
+            bannerRepository.updateSortSeq(beforeSortSeq + 1, null, -1, requestDto.getSiteId());
+            return;
+        }
+
+        int compareTo = beforeSortSeq.compareTo(afterSortSeq);
+        if (compareTo > 0) {
+            bannerRepository.updateSortSeq(afterSortSeq, beforeSortSeq - 1, 1, requestDto.getSiteId());
+            return;
+        }
+
+        if (compareTo < 0) {
+            bannerRepository.updateSortSeq(beforeSortSeq + 1, afterSortSeq, -1, requestDto.getSiteId());
+        }
     }
 
     /**

--- a/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/service/banner/BannerServiceSortSeqTest.java
+++ b/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/service/banner/BannerServiceSortSeqTest.java
@@ -1,0 +1,116 @@
+package org.egovframe.cloud.portalservice.service.banner;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.util.Optional;
+
+import org.egovframe.cloud.portalservice.api.banner.dto.BannerUpdateRequestDto;
+import org.egovframe.cloud.portalservice.domain.banner.Banner;
+import org.egovframe.cloud.portalservice.domain.banner.BannerRepository;
+import org.egovframe.cloud.portalservice.domain.menu.Site;
+import org.egovframe.cloud.portalservice.domain.menu.SiteRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.cloud.stream.function.StreamBridge;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * org.egovframe.cloud.portalservice.service.banner.BannerServiceSortSeqTest
+ * <p>
+ * 배너 수정 시 정렬 순서 조정 단위 테스트
+ *
+ * @author 표준프레임워크센터
+ * @version 1.0
+ * @since 2026/08/28
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *     수정일        수정자           수정내용
+ *  ----------    --------    ---------------------------
+ *  2026/08/28    contributors  최초 생성
+ * </pre>
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class BannerServiceSortSeqTest {
+
+    private static final Integer BANNER_NO = 1;
+    private static final Long SITE_ID = 1L;
+
+    @Mock
+    private BannerRepository bannerRepository;
+
+    @Mock
+    private SiteRepository siteRepository;
+
+    @Mock
+    private StreamBridge streamBridge;
+
+    @InjectMocks
+    private BannerService bannerService;
+
+    private void givenBannerAt(Integer sortSeq) {
+        Banner entity = Banner.builder()
+                .bannerNo(BANNER_NO)
+                .bannerTypeCode("main")
+                .bannerTitle("배너")
+                .sortSeq(sortSeq)
+                .build();
+        given(bannerRepository.findById(BANNER_NO)).willReturn(Optional.of(entity));
+        given(siteRepository.findById(SITE_ID)).willReturn(Optional.of(Site.builder().build()));
+        // 조회는 수정 대상 자신도 걸러내지 않는다.
+        given(bannerRepository.findBySortSeqAndSiteId(any(), any())).willReturn(Optional.empty());
+        given(bannerRepository.findBySortSeqAndSiteId(sortSeq, SITE_ID)).willReturn(Optional.of(entity));
+    }
+
+    private BannerUpdateRequestDto requestWithSortSeq(Integer sortSeq) {
+        BannerUpdateRequestDto requestDto = new BannerUpdateRequestDto();
+        ReflectionTestUtils.setField(requestDto, "bannerTypeCode", "main");
+        ReflectionTestUtils.setField(requestDto, "bannerTitle", "배너");
+        ReflectionTestUtils.setField(requestDto, "sortSeq", sortSeq);
+        ReflectionTestUtils.setField(requestDto, "siteId", SITE_ID);
+        return requestDto;
+    }
+
+    @DisplayName("배너 수정 시 정렬 순서가 밀려나면 사이 구간 정렬 순서를 1씩 줄인다")
+    @Test
+    void should_decreaseSortSeqBetweenRange_when_sortSeqIsPostponed() {
+        givenBannerAt(1);
+
+        bannerService.update(BANNER_NO, requestWithSortSeq(3));
+
+        verify(bannerRepository).updateSortSeq(2, 3, -1, SITE_ID);
+    }
+
+    @DisplayName("배너 수정 시 정렬 순서가 당겨지면 사이 구간 정렬 순서를 1씩 늘린다")
+    @Test
+    void should_increaseSortSeqBetweenRange_when_sortSeqIsAdvanced() {
+        givenBannerAt(3);
+
+        bannerService.update(BANNER_NO, requestWithSortSeq(1));
+
+        verify(bannerRepository).updateSortSeq(1, 2, 1, SITE_ID);
+    }
+
+    @DisplayName("배너 수정 시 정렬 순서가 그대로면 다른 배너를 건드리지 않는다")
+    @Test
+    void should_notTouchOtherBanners_when_sortSeqIsUnchanged() {
+        givenBannerAt(2);
+
+        bannerService.update(BANNER_NO, requestWithSortSeq(2));
+
+        verify(bannerRepository, never()).updateSortSeq(anyInt(), any(), anyInt(), anyLong());
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`BannerService.update`는 `save`의 정렬 순서 처리를 그대로 씁니다. 주석과 지역 변수 이름까지 같습니다.

```java
// 동일한 정렬 순서가 존재할 경우 +1
Optional<Banner> authorization = bannerRepository.findBySortSeqAndSiteId(requestDto.getSortSeq(), requestDto.getSiteId());
if (authorization.isPresent()) {
    bannerRepository.updateSortSeq(requestDto.getSortSeq(), null, 1, requestDto.getSiteId());
}
```

등록에는 맞는 규칙이지만 수정에는 두 가지가 어긋납니다. `findBySortSeqAndSiteId`는 사이트와 정렬 순서만으로 찾으므로 **수정 대상 자신도 함께 반환**하고, 뒤로 옮길 때 필요한 사이 구간 `-1` 조정이 없습니다.

배너 A(1) B(2) C(3)이 있을 때입니다.

- A를 **2**로 옮기면 조회가 B를 찾아 2 이상을 전부 +1 합니다. B=3, C=4가 되고 A는 1이라 시프트에 걸리지 않은 채 2가 됩니다. 결과는 A=2 B=3 C=4로, 화면 순서가 A B C 그대로입니다. 한 칸 내리는 조작이 반영되지 않습니다.
- A를 **3**으로 옮기면 C만 +1 되어 A=3 B=2 C=4가 됩니다. 화면 순서는 B A C이고 기대한 B C A가 아닙니다.

같은 저장소의 `AuthorizationService`는 같은 시그니처의 `updateSortSeq(start, end, increase)`를 쓰면서 수정에서는 앞뒤 구간을 나눠 조정합니다.

```java
// AuthorizationService.updateSortSeq(entity, requestDto)
int compareTo = beforeSortSeq.compareTo(afterSortSeq);
if (compareTo > 0) {
    authorizationRepository.updateSortSeq(afterSortSeq, beforeSortSeq-1, 1);
    return;
}
if (compareTo < 0) {
    authorizationRepository.updateSortSeq(beforeSortSeq+1, afterSortSeq, -1);
    return;
}
```

이 규칙을 사이트 인자만 더해 `BannerService`로 옮겼습니다. `BannerRepositoryImpl.updateSortSeq`는 이미 종료 구간과 음수 증감을 받도록 되어 있어 리포지토리는 그대로입니다.

등록 경로는 자기 자신이 없으므로 손대지 않았습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

`AuthorizationServiceTest`의 "인가 수정 시 정렬 순서가 밀려나면 사이 구간 정렬 순서를 1씩 줄인다"와 같은 형태로, 뒤로 이동·앞으로 이동·변경 없음 세 경우를 확인합니다. 조회가 수정 대상 자신을 반환하는 것도 그대로 재현합니다.

수정 전(RED)

```
BannerServiceSortSeqTest > 배너 수정 시 정렬 순서가 당겨지면 사이 구간 정렬 순서를 1씩 늘린다 FAILED
BannerServiceSortSeqTest > 배너 수정 시 정렬 순서가 밀려나면 사이 구간 정렬 순서를 1씩 줄인다 FAILED
BannerServiceSortSeqTest > 배너 수정 시 정렬 순서가 그대로면 다른 배너를 건드리지 않는다 FAILED
3 tests completed, 3 failed
```

수정 후(GREEN)

```
BUILD SUCCESSFUL
```

`portal-service` 전체 스위트는 이 변경 전후가 같습니다 — 70건 실패이고 실패 클래스와 건수가 변경 전 `main`과 동일합니다.

## 테스트 브라우저 Test Browser

서버측 정렬 순서 계산 수정이라 브라우저와 무관합니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면 변경이 없어 첨부하지 않았습니다.
