### PR TITLE
fix(user-service): 가입되지 않은 이메일의 로그인 실패 후처리가 예외로 중단되는 문제 수정

### DIFF
--- a/backend/user-service/src/main/java/org/egovframe/cloud/userservice/service/user/UserService.java
+++ b/backend/user-service/src/main/java/org/egovframe/cloud/userservice/service/user/UserService.java
@@ -289,13 +289,13 @@ public class UserService extends AbstractService implements UserDetailsService {
      */
     @Transactional
     public void loginCallback(Long siteId, String email, Boolean successAt, String failContent) {
-        User user = userRepository.findByEmail(email)
-                .orElseThrow(() -> new IllegalArgumentException(getMessage("err.user.notexists")));
+        // 가입되지 않은 이메일로도 로그인 실패 후처리가 들어온다.
+        Optional<User> user = userRepository.findByEmail(email);
 
         if (Boolean.TRUE.equals(successAt)) {
-            user.successLogin();
+            user.ifPresent(User::successLogin);
         } else {
-            user.failLogin();
+            user.ifPresent(User::failLogin);
         }
 
         // 로그인 로그 입력

--- a/backend/user-service/src/test/java/org/egovframe/cloud/userservice/service/user/UserServiceLoginCallbackTest.java
+++ b/backend/user-service/src/test/java/org/egovframe/cloud/userservice/service/user/UserServiceLoginCallbackTest.java
@@ -1,0 +1,102 @@
+package org.egovframe.cloud.userservice.service.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import java.util.Optional;
+
+import org.egovframe.cloud.common.util.MessageUtil;
+import org.egovframe.cloud.userservice.domain.log.LoginLog;
+import org.egovframe.cloud.userservice.domain.log.LoginLogRepository;
+import org.egovframe.cloud.userservice.domain.user.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+/**
+ * org.egovframe.cloud.userservice.service.user.UserServiceLoginCallbackTest
+ * <p>
+ * 로그인 후처리에서 가입되지 않은 이메일을 다루는 회귀 테스트.
+ *
+ * AuthenticationFilter.unsuccessfulAuthentication 은 "해당 사용자가 없습니다" 를 별도
+ * 분기로 다루면서 loginCallback 에 실패 사유를 넘긴다. 로그인 실패 감사 로그는 가입
+ * 여부와 무관하게 남아야 한다.
+ *
+ * @author 표준프레임워크센터
+ * @version 1.0
+ * @since 2026/08/28
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *     수정일        수정자           수정내용
+ *  ----------    --------    ---------------------------
+ *  2026/08/28    contributors  최초 생성
+ * </pre>
+ */
+@ExtendWith(MockitoExtension.class)
+class UserServiceLoginCallbackTest {
+
+    private static final Long SITE_ID = 1L;
+    private static final String UNKNOWN_EMAIL = "notjoined@egovframe.org";
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private LoginLogRepository loginLogRepository;
+
+    @Mock
+    private MessageUtil messageUtil;
+
+    @InjectMocks
+    private UserService userService;
+
+    @Captor
+    private ArgumentCaptor<LoginLog> loginLogCaptor;
+
+    @BeforeEach
+    void bindRequest() {
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(new MockHttpServletRequest()));
+        ReflectionTestUtils.setField(userService, "messageUtil", messageUtil);
+    }
+
+    @AfterEach
+    void unbindRequest() {
+        RequestContextHolder.resetRequestAttributes();
+    }
+
+    @DisplayName("가입되지 않은 이메일의 로그인 실패도 후처리를 마친다")
+    @Test
+    void loginCallback_with_unknown_email() {
+        given(userRepository.findByEmail(UNKNOWN_EMAIL)).willReturn(Optional.empty());
+
+        assertThatCode(() -> userService.loginCallback(SITE_ID, UNKNOWN_EMAIL, false, "해당 사용자가 없습니다"))
+                .doesNotThrowAnyException();
+    }
+
+    @DisplayName("가입되지 않은 이메일의 로그인 실패도 로그인 로그로 남는다")
+    @Test
+    void loginCallback_saves_login_log_for_unknown_email() {
+        given(userRepository.findByEmail(UNKNOWN_EMAIL)).willReturn(Optional.empty());
+
+        userService.loginCallback(SITE_ID, UNKNOWN_EMAIL, false, "해당 사용자가 없습니다");
+
+        verify(loginLogRepository).save(loginLogCaptor.capture());
+        assertThat(loginLogCaptor.getValue().getEmail()).isEqualTo(UNKNOWN_EMAIL);
+        assertThat(loginLogCaptor.getValue().getSuccessAt()).isFalse();
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`AuthenticationFilter.unsuccessfulAuthentication`은 사용자가 없는 경우를 별도 분기로 다룬 뒤 `loginCallback`을 호출합니다.

```java
if (failed instanceof InternalAuthenticationServiceException) {
    log.info("{} 해당 사용자가 없습니다", request.getAttribute("email"));
} else if (failed instanceof BadCredentialsException) {
    failContent = "패스워드 인증에 실패하였습니다. " + failContent;
}
response.setStatus(HttpStatus.UNAUTHORIZED.value());

// 로그인 실패 후처리
String email = (String) request.getAttribute("email");
userService.loginCallback(LogUtil.getSiteId(request), email, false, failContent);
super.unsuccessfulAuthentication(request, response, failed);
```

그런데 `loginCallback`은 사용자 존재를 요구합니다.

```java
User user = userRepository.findByEmail(email)
        .orElseThrow(() -> new IllegalArgumentException(getMessage("err.user.notexists")));
```

미가입 이메일로 로그인하면 여기서 `IllegalArgumentException`이 납니다. 이 예외는 `doFilter`의 catch 세 곳(`BusinessException`·`JwtException`·`ServletException | IOException`)에 걸리지 않으므로 `super.unsuccessfulAuthentication`이 실행되지 않고, 로그인 실패 로그도 남지 않습니다.

확인한 것은 `loginCallback`이 예외로 끝나 후처리와 로그 저장을 못 마친다는 데까지입니다. 응답 상태가 무엇으로 바뀌는지는 이 저장소의 통합 테스트가 로컬에서 돌지 않아 재현하지 못했습니다.

AS-IS / TO-BE

```diff
-        User user = userRepository.findByEmail(email)
-                .orElseThrow(() -> new IllegalArgumentException(getMessage("err.user.notexists")));
+        Optional<User> user = userRepository.findByEmail(email);
 
         if (Boolean.TRUE.equals(successAt)) {
-            user.successLogin();
+            user.ifPresent(User::successLogin);
         } else {
-            user.failLogin();
+            user.ifPresent(User::failLogin);
         }
```

로그인 로그 저장은 그대로 두어 가입 여부와 무관하게 남습니다. 성공 경로는 사용자가 반드시 존재하므로 동작이 바뀌지 않습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

수정 전(RED)

```
UserServiceLoginCallbackTest > 가입되지 않은 이메일의 로그인 실패도 후처리를 마친다
  java.lang.IllegalArgumentException
2 tests completed, 2 failed
```

수정 후(GREEN)

```
BUILD SUCCESSFUL
```

`user-service` 전체 스위트는 이 변경 전후가 같습니다 — 30건 실패이고 실패 클래스와 건수가 변경 전 `main`과 동일합니다.

## 테스트 브라우저 Test Browser

서버측 로그인 후처리 수정이라 브라우저와 무관합니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면 변경이 없어 첨부하지 않았습니다.
