### PR TITLE
fix(frontend): 로그인 폼이 6자 초과 최상위 도메인 이메일을 거부하는 문제 수정

### DIFF
--- a/frontend/admin/src/components/Auth/LoginForm.tsx
+++ b/frontend/admin/src/components/Auth/LoginForm.tsx
@@ -14,6 +14,7 @@ import { useForm } from 'react-hook-form'
 import { PageProps } from '@pages/_app'
 import { EmailStorage } from '@libs/Storage/emailStorage'
 import { DEFAULT_APP_NAME } from '@constants'
+import { EMAIL_PATTERN } from '@utils'
 
 const useStyles = makeStyles((theme: Theme) => ({
   paper: {
@@ -112,8 +113,7 @@ const LoginForm = ({ handleLogin, errorMessage }: ILoginFormProps) => {
             {...register('email', {
               required: 'Email Address is required!!',
               pattern: {
-                value:
-                  /^[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*\.[a-zA-Z]{2,3}$/i,
+                value: EMAIL_PATTERN,
                 message: 'Email Address의 형식이 맞지 않습니다.',
               },
             })}

--- a/frontend/admin/src/utils/__tests__/emailPattern.test.ts
+++ b/frontend/admin/src/utils/__tests__/emailPattern.test.ts
@@ -1,0 +1,32 @@
+import { EMAIL_PATTERN } from '../index'
+
+describe('EMAIL_PATTERN', () => {
+  describe('정상 이메일은 통과한다', () => {
+    const validEmails = [
+      'user@example.com',
+      'user@example.io',
+      'user.name@example.co.kr',
+      'user-name@sub.example.com',
+      // 6자를 초과하는 신규 일반 최상위 도메인(gTLD)
+      'user@example.technology',
+      'user@example.engineering',
+      'user@example.international',
+    ]
+
+    validEmails.forEach(email => {
+      it(`${email}`, () => {
+        expect(EMAIL_PATTERN.test(email)).toBe(true)
+      })
+    })
+  })
+
+  describe('비정상 이메일은 거부한다', () => {
+    const invalidEmails = ['', 'user', 'user@', 'user@example', '@example.com', 'a@b.c']
+
+    invalidEmails.forEach(email => {
+      it(`${email || '(빈 문자열)'}`, () => {
+        expect(EMAIL_PATTERN.test(email)).toBe(false)
+      })
+    })
+  })
+})

--- a/frontend/admin/src/utils/index.ts
+++ b/frontend/admin/src/utils/index.ts
@@ -72,3 +72,7 @@ export const translateToLang = (
 
   return data[otherKey]
 }
+
+// 이메일 형식 정규식 (최상위 도메인 길이는 DNS 라벨 최대치인 63자까지 허용)
+export const EMAIL_PATTERN =
+  /^([\w-]+(?:\.[\w-]+)*)@((?:[\w-]+\.)*\w[\w-]{0,66})\.([a-z]{2,63}(?:\.[a-z]{2})?)$/i

--- a/frontend/portal/src/components/Auth/LoginForm.tsx
+++ b/frontend/portal/src/components/Auth/LoginForm.tsx
@@ -1,5 +1,6 @@
 import ValidationAlert from '@components/ValidationAlert'
 import { EmailStorage } from '@libs/Storage/emailStorage'
+import { EMAIL_PATTERN } from '@utils'
 import Alert from '@material-ui/lab/Alert'
 import React, { useState } from 'react'
 import { useForm } from 'react-hook-form'
@@ -77,8 +78,7 @@ const LoginForm = (props: LoginFormProps) => {
           {...register('email', {
             required: `${t('user.email')} ${t('valid.required')}`,
             pattern: {
-              value:
-                /^[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*\.[a-zA-Z]{2,3}$/i,
+              value: EMAIL_PATTERN,
               message: `${t('user.email')} ${t('valid.format_not_match')}`,
             },
           })}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

포털·관리자 로그인 폼만 자체 인라인 정규식을 씁니다. 최상위 도메인을 2~3자로 제한합니다.

```tsx
pattern: {
  value:
    /^[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*\.[a-zA-Z]{2,3}$/i,
```

같은 앱의 가입·비밀번호찾기·회원정보수정은 공용 `EMAIL_PATTERN`을 쓰고, 그 패턴은 최상위 도메인을 63자까지 허용합니다. `isValidEmail.test.ts`가 `user@example.technology`를 유효로 고정해 두었습니다.

그래서 `user@example.technology`로 가입하면 계정은 만들어지는데, 같은 주소로 로그인하려 하면 폼 검증에 걸려 요청이 전송되지 않습니다.

`#80`이 같은 성격의 제한을 세 파일에서 공용 패턴으로 바꿨지만 로그인 폼은 남았습니다. 저장소에 인라인 이메일 정규식이 남은 곳은 두 로그인 폼뿐입니다.

AS-IS / TO-BE

```diff
-              value:
-                /^[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*\.[a-zA-Z]{2,3}$/i,
+              value: EMAIL_PATTERN,
```

관리자에는 공용 상수가 없어 포털과 같은 정의를 `src/utils/index.ts`에 추가했습니다.

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

관리자에 추가한 상수는 포털의 `isValidEmail.test.ts`를 참고해 확인합니다. 유효 목록은 같고, 무효 목록에서 공백이 든 주소는 관리자 화면에 해당 입력 경로가 없어 뺐습니다.

```
Test Suites: 1 passed, 1 total
Tests:       13 passed, 13 total
```

포털의 기존 테스트도 그대로 통과합니다(3파일 38건). 두 앱 모두 빌드 오류가 없습니다.

추가한 테스트는 상수 자체를 고정하는 것이라 두 로그인 폼의 바인딩 변경까지 증명하지는 않습니다. 이 저장소에는 컴포넌트 테스트 전례가 없어 빌드와 상수 테스트로 대신했습니다.

### 이 PR 의 프론트엔드 체크가 실패하는 이유

`build (portal)`·`build (admin)`은 이 변경과 무관하게 실패합니다. 워크플로가 추가된 2026-08-21 이후 `main` 을 포함해 모든 실행이 같은 지점에서 멈춥니다.

```
Error: error:0308010C:digital envelope routines::unsupported
```

Next.js 11 의 webpack 이 MD4 를 쓰는데 OpenSSL 3 에 없기 때문이고, 컴파일 전에 멈추므로 이 변경의 타입 오류나 모듈 해석 오류는 아닙니다. #251 에서 따로 다루고 있습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

정규식 상수 교체라 브라우저별 차이가 없어 빌드와 단위 테스트로 확인했습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면 변경이 없어 첨부하지 않았습니다.
