### PR TITLE
fix(reserve-request-service): 공간·장비 예약 신청의 첨부파일이 예약에 연결되지 않는 문제 수정

### DIFF
--- a/backend/reserve-request-service/src/main/java/org/egovframe/cloud/reserverequestservice/service/ReserveService.java
+++ b/backend/reserve-request-service/src/main/java/org/egovframe/cloud/reserverequestservice/service/ReserveService.java
@@ -25,6 +25,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.ReactiveSecurityContextHolder;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
@@ -79,12 +80,7 @@ public class ReserveService extends ReactiveAbstractService {
                 return Mono.just(reserve);
             })
             .flatMap(reserveRepository::insert)
-            .doOnNext(reserve -> sendAttachmentEntityInfo(streamBridge,
-                AttachmentEntityMessage.builder()
-                    .attachmentCode(reserve.getAttachmentCode())
-                    .entityName(reserve.getClass().getName())
-                    .entityId(reserve.getReserveId())
-                    .build()))
+            .doOnNext(this::sendAttachmentEvent)
             .flatMap(this::convertReserveResponseDto);
     }
 
@@ -145,7 +141,26 @@ public class ReserveService extends ReactiveAbstractService {
                 return Mono.just(reserve);
             })
             .flatMap(reserveRepository::insert)
+            .doOnNext(this::sendAttachmentEvent)
             .flatMap(this::convertReserveResponseDto);
+    }
+
+    /**
+     * 첨부파일을 예약 정보에 연결하기 위해 이벤트 메시지 발행
+     *
+     * @param reserve 저장된 예약
+     */
+    private void sendAttachmentEvent(Reserve reserve) {
+        if (!StringUtils.hasText(reserve.getAttachmentCode())) {
+            return;
+        }
+
+        sendAttachmentEntityInfo(streamBridge,
+            AttachmentEntityMessage.builder()
+                .attachmentCode(reserve.getAttachmentCode())
+                .entityName(reserve.getClass().getName())
+                .entityId(reserve.getReserveId())
+                .build());
     }
 
     /**

--- a/backend/reserve-request-service/src/test/java/org/egovframe/cloud/reserverequestservice/service/ReserveServiceAttachmentEventTest.java
+++ b/backend/reserve-request-service/src/test/java/org/egovframe/cloud/reserverequestservice/service/ReserveServiceAttachmentEventTest.java
@@ -1,0 +1,127 @@
+package org.egovframe.cloud.reserverequestservice.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+
+import org.egovframe.cloud.common.dto.AttachmentEntityMessage;
+import org.egovframe.cloud.reserverequestservice.api.dto.ReserveSaveRequestDto;
+import org.egovframe.cloud.reserverequestservice.domain.Reserve;
+import org.egovframe.cloud.reserverequestservice.domain.ReserveRepository;
+import org.egovframe.cloud.reserverequestservice.domain.ReserveValidator;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.amqp.core.AmqpAdmin;
+import org.springframework.cloud.stream.function.StreamBridge;
+import org.springframework.messaging.Message;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
+
+import reactor.core.publisher.Mono;
+
+/**
+ * org.egovframe.cloud.reserverequestservice.service.ReserveServiceAttachmentEventTest
+ * <p>
+ * 예약 신청 두 경로가 첨부파일 바인딩 이벤트를 발행하는지 확인하는 단위 테스트
+ *
+ * @author 표준프레임워크센터
+ * @version 1.0
+ * @since 2026/08/28
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *     수정일        수정자           수정내용
+ *  ----------    --------    ---------------------------
+ *  2026/08/28    contributors  최초 생성
+ * </pre>
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ReserveServiceAttachmentEventTest {
+
+    private static final String USER_ID = "user-1";
+    private static final String ATTACHMENT_CODE = "ATT-1";
+
+    @Mock
+    private ReserveRepository reserveRepository;
+
+    @Mock
+    private ReserveValidator reserveValidator;
+
+    @Mock
+    private StreamBridge streamBridge;
+
+    @Mock
+    private AmqpAdmin amqpAdmin;
+
+    @InjectMocks
+    private ReserveService reserveService;
+
+    @Captor
+    private ArgumentCaptor<Message<AttachmentEntityMessage>> messageCaptor;
+
+    private ReserveSaveRequestDto saveRequestDto() {
+        return ReserveSaveRequestDto.builder()
+                .reserveItemId(101L)
+                .locationId(7L)
+                .categoryId("space")
+                .reserveQty(1)
+                .reservePurposeContent("회의실 예약 사유")
+                .attachmentCode(ATTACHMENT_CODE)
+                .reserveStartDate(LocalDateTime.of(2026, 6, 1, 10, 0))
+                .reserveEndDate(LocalDateTime.of(2026, 6, 1, 12, 0))
+                .userId(USER_ID)
+                .userContactNo("010-0000-0000")
+                .userEmail("user@example.com")
+                .build();
+    }
+
+    private void givenSavedReserve() {
+        given(reserveValidator.checkSpace(any())).willAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+        given(reserveValidator.checkEquipment(any())).willAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+        given(reserveRepository.insert(any(Reserve.class)))
+                .willAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+    }
+
+    private <T> T withLogin(Mono<T> mono) {
+        return mono.contextWrite(ReactiveSecurityContextHolder.withAuthentication(
+                new UsernamePasswordAuthenticationToken(USER_ID, null, Collections.emptyList()))).block();
+    }
+
+    @DisplayName("실시간 예약 신청도 첨부파일 바인딩 이벤트를 발행한다")
+    @Test
+    void save_publishes_attachment_event() {
+        givenSavedReserve();
+
+        withLogin(reserveService.save(saveRequestDto()));
+
+        verify(streamBridge).send(anyString(), messageCaptor.capture());
+        assertThat(messageCaptor.getValue().getPayload().getAttachmentCode()).isEqualTo(ATTACHMENT_CODE);
+        assertThat(messageCaptor.getValue().getPayload().getEntityId()).isNotNull();
+    }
+
+    @DisplayName("심사 예약 신청은 첨부파일 바인딩 이벤트를 발행한다")
+    @Test
+    void create_publishes_attachment_event() {
+        givenSavedReserve();
+
+        withLogin(reserveService.create(saveRequestDto()));
+
+        verify(streamBridge).send(anyString(), messageCaptor.capture());
+        assertThat(messageCaptor.getValue().getPayload().getAttachmentCode()).isEqualTo(ATTACHMENT_CODE);
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

같은 클래스의 두 신청 경로가 갈립니다.

```java
// create() — 심사 신청
.flatMap(reserveRepository::insert)
.doOnNext(reserve -> sendAttachmentEntityInfo(streamBridge, ...))
.flatMap(this::convertReserveResponseDto);

// save() — 실시간 신청
.flatMap(reserveRepository::insert)
.flatMap(this::convertReserveResponseDto);
```

첨부파일은 업로드 시점에 `entityId`를 임시값으로 두고, 도메인이 저장된 뒤 이 이벤트로 채워집니다. `save()`는 그 이벤트를 발행하지 않으므로 첨부의 `entity_id`가 임시값으로 남습니다.

`POST /api/v1/requests`는 교육 물품이면 `saveForEvent()`로 갈라지고 그쪽은 `create()`를 거치므로 영향이 없습니다. 남는 것은 공간·장비 신청이 지나가는 `save()` 경로입니다.

같은 값이 첨부 삭제 가드에도 쓰입니다. 저장이 끝난 건의 파일은 지우지 못하게 되어 있는데, 실시간 경로로 올린 첨부는 그 가드에 걸리지 않습니다.

AS-IS / TO-BE

```diff
             .flatMap(reserveRepository::insert)
+            .doOnNext(this::sendAttachmentEvent)
             .flatMap(this::convertReserveResponseDto);
```

두 경로가 같은 헬퍼를 쓰도록 정리했습니다.

```java
private void sendAttachmentEvent(Reserve reserve) {
    if (!StringUtils.hasText(reserve.getAttachmentCode())) {
        return;
    }
    sendAttachmentEntityInfo(streamBridge, AttachmentEntityMessage.builder()...);
}
```

첨부가 없을 때는 발행하지 않는 가드를 함께 넣었습니다. 기존 `create()`는 첨부 없이 신청해도 이벤트를 보냈습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

두 경로를 같은 요청 DTO로 호출해 발행 여부를 비교합니다.

수정 전(RED)

```
ReserveServiceAttachmentEventTest > 실시간 예약 신청도 첨부파일 바인딩 이벤트를 발행한다 FAILED
  Wanted but not invoked: streamBridge.send(...)
2 tests completed, 1 failed
```

심사 경로 테스트는 수정 전에도 통과합니다.

수정 후(GREEN)

```
BUILD SUCCESSFUL
```

`reserve-request-service` 전체 스위트는 이 변경 전후가 같습니다 — 2건 실패이고 실패 클래스가 변경 전 `main`과 동일합니다.

## 테스트 브라우저 Test Browser

서버측 이벤트 발행 수정이라 브라우저와 무관합니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면 변경이 없어 첨부하지 않았습니다.
