### PR TITLE
fix(portal): 회원정보 수정에서 중복확인 결과가 이메일을 바꿔도 유지되는 문제 수정

### DIFF
--- a/frontend/portal/src/components/UserInfo/UserInfoModified.tsx
+++ b/frontend/portal/src/components/UserInfo/UserInfoModified.tsx
@@ -51,6 +51,7 @@ const UserInfoModified = (props: UserInfoModifiedPrpps) => {
     try {
       const result = await userService.existsEmail(emailValue, user.userId)
       if (result === true) {
+        setCheckedEmail(false)
         showMessage(t('msg.user.email.exists'), () => {
           setFocus('email')
         })
@@ -103,6 +104,9 @@ const UserInfoModified = (props: UserInfoModifiedPrpps) => {
                 placeholder={t('user.email')}
                 inputMode="email"
                 maxLength={50}
+                onInput={() => {
+                  setCheckedEmail(false)
+                }}
               />
               <ActiveLink href="" handleActiveLinkClick={handleCheckEmail}>
                 {t('label.button.check_email')}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

회원정보 수정에서 이메일을 바꿔 저장하려면 `checkedEmail` 플래그가 참이어야 합니다. 그런데 이 화면은 플래그를 `true`로 올리기만 하고 되돌리는 곳이 없습니다.

```tsx
// UserInfoModified.tsx handleCheckEmail
if (result === true) {
  showMessage(t('msg.user.email.exists'), () => {
    setFocus('email')
  })
} else {
  showMessage(t('msg.user.email.notexists'))
  setCheckedEmail(true)
}
```

같은 값을 같은 방식으로 쓰는 회원가입 폼은 두 곳에서 내립니다.

```tsx
// pages/auth/join/form.tsx
if (result === true) {
  setCheckedEmail(false)
  ...
}

// 같은 파일 이메일 입력
onInput={event => {
  setCheckedEmail(false)
}}
```

그래서 수정 화면에서는 중복확인을 통과한 뒤 다른 주소로 고쳐 써도, 다시 확인해 이미 사용중이라는 결과가 나와도 게이트가 열린 채로 남습니다.

AS-IS / TO-BE

```diff
       if (result === true) {
+        setCheckedEmail(false)
         showMessage(t('msg.user.email.exists'), () => {
```

```diff
                 maxLength={50}
+                onInput={() => {
+                  setCheckedEmail(false)
+                }}
               />
```

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

이 저장소의 프론트엔드 테스트는 순수 유틸 단위 테스트뿐이라 컴포넌트 상태를 다루는 테스트 전례가 없습니다. 같은 성격의 컴포넌트 수정인 #103도 테스트 없이 반영됐습니다.

포털 빌드에 오류가 없고 기존 테스트 38건이 그대로 통과하는 것으로 확인했습니다.

`build (portal)`·`build (admin)` 체크는 이 변경과 무관하게 실패합니다. 워크플로가 추가된 이후 `main` 을 포함해 모든 실행이 `error:0308010C:digital envelope routines::unsupported` 에서 멈추며, #251 에서 따로 다루고 있습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

상태 플래그 처리 수정이라 브라우저별 차이가 없습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면 자체는 바뀌지 않아 첨부하지 않았습니다.
