### PR TITLE
fix(board-service): 대댓글 등록이 다른 게시물의 댓글 정렬 순서까지 바꾸는 문제 수정

### DIFF
--- a/backend/board-service/src/main/java/org/egovframe/cloud/boardservice/domain/comment/CommentRepositoryCustom.java
+++ b/backend/board-service/src/main/java/org/egovframe/cloud/boardservice/domain/comment/CommentRepositoryCustom.java
@@ -101,12 +101,14 @@ public interface CommentRepositoryCustom {
     /**
      * 댓글 정렬 순서 수정
      *
+     * @param boardNo         게시판 번호
+     * @param postsNo         게시물 번호
      * @param groupNo         그룹 번호
      * @param startSortSeq    시작 정렬 순서
      * @param endSortSeq      종료 정렬 순서
      * @param increaseSortSeq 증가 정렬 순서
      * @return Long 처리 건수
      */
-    Long updateSortSeq(Integer groupNo, Integer startSortSeq, Integer endSortSeq, int increaseSortSeq);
+    Long updateSortSeq(Integer boardNo, Integer postsNo, Integer groupNo, Integer startSortSeq, Integer endSortSeq, int increaseSortSeq);
 
 }

--- a/backend/board-service/src/main/java/org/egovframe/cloud/boardservice/domain/comment/CommentRepositoryImpl.java
+++ b/backend/board-service/src/main/java/org/egovframe/cloud/boardservice/domain/comment/CommentRepositoryImpl.java
@@ -288,16 +288,20 @@ public class CommentRepositoryImpl implements CommentRepositoryCustom {
     /**
      * 댓글 정렬 순서 수정
      *
+     * @param boardNo         게시판 번호
+     * @param postsNo         게시물 번호
      * @param groupNo         그룹 번호
      * @param startSortSeq    시작 정렬 순서
      * @param endSortSeq      종료 정렬 순서
      * @param increaseSortSeq 증가 정렬 순서
      * @return Long 수정 건수
      */
-    public Long updateSortSeq(Integer groupNo, Integer startSortSeq, Integer endSortSeq, int increaseSortSeq) {
+    public Long updateSortSeq(Integer boardNo, Integer postsNo, Integer groupNo, Integer startSortSeq, Integer endSortSeq, int increaseSortSeq) {
         return jpaQueryFactory.update(comment)
                 .set(comment.sortSeq, comment.sortSeq.add(increaseSortSeq))
-                .where(isEqualsGroupNo(groupNo),
+                .where(comment.commentId.postsId.boardNo.eq(boardNo),
+                        comment.commentId.postsId.postsNo.eq(postsNo),
+                        isEqualsGroupNo(groupNo),
                         isGoeSortSeq(startSortSeq),
                         isLoeSortSeq(endSortSeq))
                 .execute();

--- a/backend/board-service/src/main/java/org/egovframe/cloud/boardservice/service/comment/CommentService.java
+++ b/backend/board-service/src/main/java/org/egovframe/cloud/boardservice/service/comment/CommentService.java
@@ -138,7 +138,7 @@ public class CommentService extends AbstractService {
         if (requestDto.getParentCommentNo() != null) { // 대댓글
             sortSeq = commentRepository.findNextSortSeq(requestDto.getBoardNo(), requestDto.getPostsNo(), requestDto.getGroupNo(), requestDto.getParentCommentNo(), requestDto.getDepthSeq());
             if (sortSeq != null) {
-                commentRepository.updateSortSeq(requestDto.getGroupNo(), sortSeq, null, 1); // 들어갈 위치와 같거나 큰 대댓글 정렬 순서 +1
+                commentRepository.updateSortSeq(requestDto.getBoardNo(), requestDto.getPostsNo(), requestDto.getGroupNo(), sortSeq, null, 1); // 들어갈 위치와 같거나 큰 대댓글 정렬 순서 +1
             } else {
                 sortSeq = commentRepository.findLastSortSeq(requestDto.getBoardNo(), requestDto.getPostsNo(), requestDto.getGroupNo()); // 들어갈 위치가 검색되지 않으면 max
             }

--- a/backend/board-service/src/test/java/org/egovframe/cloud/boardservice/domain/comment/CommentRepositoryScopeTest.java
+++ b/backend/board-service/src/test/java/org/egovframe/cloud/boardservice/domain/comment/CommentRepositoryScopeTest.java
@@ -1,0 +1,134 @@
+package org.egovframe.cloud.boardservice.domain.comment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import org.egovframe.cloud.boardservice.domain.board.Board;
+import org.egovframe.cloud.boardservice.domain.board.BoardRepository;
+import org.egovframe.cloud.boardservice.domain.posts.Posts;
+import org.egovframe.cloud.boardservice.domain.posts.PostsId;
+import org.egovframe.cloud.boardservice.domain.posts.PostsRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import jakarta.persistence.EntityManager;
+
+/**
+ * org.egovframe.cloud.boardservice.domain.comment.CommentRepositoryScopeTest
+ * <p>
+ * 댓글 정렬 순서 일괄 수정이 게시물 범위를 벗어나지 않는지 확인한다.
+ *
+ * @author 표준프레임워크센터
+ * @version 1.0
+ * @since 2026/08/28
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *     수정일        수정자           수정내용
+ *  ----------    --------    ---------------------------
+ *  2026/08/28    contributors  최초 생성
+ * </pre>
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@EnableConfigurationProperties
+@ActiveProfiles(profiles = "test")
+@Transactional
+class CommentRepositoryScopeTest {
+
+    private static final Integer POSTS_ONE = 901;
+    private static final Integer POSTS_TWO = 902;
+    private static final Integer GROUP_NO = 1;
+
+    @Autowired
+    private EntityManager em;
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    @Autowired
+    private PostsRepository postsRepository;
+
+    @Autowired
+    private BoardRepository boardRepository;
+
+    private Integer boardNo;
+
+    private void givenCommentsOn(Integer postsNo) {
+        PostsId postsId = PostsId.builder().boardNo(boardNo).postsNo(postsNo).build();
+        Posts posts = postsRepository.save(Posts.builder()
+                .board(boardRepository.findById(boardNo).orElseThrow())
+                .postsId(postsId)
+                .postsTitle("게시물 " + postsNo)
+                .postsContent("본문")
+                .readCount(0)
+                .noticeAt(false)
+                .deleteAt(0)
+                .build());
+
+        for (int commentNo = 1; commentNo <= 2; commentNo++) {
+            commentRepository.save(Comment.builder()
+                    .posts(posts)
+                    .commentId(CommentId.builder().postsId(postsId).commentNo(commentNo).build())
+                    .commentContent("댓글 " + commentNo)
+                    .groupNo(GROUP_NO)
+                    .depthSeq(0)
+                    .sortSeq(commentNo)
+                    .deleteAt(0)
+                    .build());
+        }
+    }
+
+    private List<Integer> sortSeqOf(Integer postsNo) {
+        return commentRepository.findAll().stream()
+                .filter(comment -> boardNo.equals(comment.getCommentId().getPostsId().getBoardNo()))
+                .filter(comment -> postsNo.equals(comment.getCommentId().getPostsId().getPostsNo()))
+                .sorted((a, b) -> a.getCommentId().getCommentNo() - b.getCommentId().getCommentNo())
+                .map(Comment::getSortSeq)
+                .toList();
+    }
+
+    @BeforeEach
+    void setUp() {
+        boardNo = boardRepository.save(Board.builder()
+                .boardName("테스트 게시판")
+                .skinTypeCode("normal")
+                .titleDisplayLength(50)
+                .postDisplayCount(10)
+                .pageDisplayCount(10)
+                .newDisplayDayCount(3)
+                .editorUseAt(false)
+                .userWriteAt(true)
+                .commentUseAt(true)
+                .uploadUseAt(false)
+                .uploadLimitCount(0)
+                .uploadLimitSize(BigDecimal.ZERO)
+                .build()).getBoardNo();
+        givenCommentsOn(POSTS_ONE);
+        givenCommentsOn(POSTS_TWO);
+    }
+
+    @DisplayName("정렬 순서 일괄 수정은 지정한 게시물의 댓글만 바꾼다")
+    @Test
+    void updateSortSeq_only_touches_given_posts() {
+        em.flush();
+        em.clear();
+
+        commentRepository.updateSortSeq(boardNo, POSTS_ONE, GROUP_NO, 1, null, 1);
+
+        em.clear();
+
+        assertThat(sortSeqOf(POSTS_ONE)).containsExactly(2, 3);
+        assertThat(sortSeqOf(POSTS_TWO))
+                .as("다른 게시물의 댓글은 그대로여야 한다")
+                .containsExactly(1, 2);
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`groupNo`는 게시물 단위로 채번됩니다. 최상위 댓글의 `groupNo`는 `findNextCommentNo(boardNo, postsNo)`가 준 `commentNo`이므로, 댓글이 있는 거의 모든 게시물에 `groupNo` 1이 존재합니다.

```java
Integer commentNo = commentRepository.findNextCommentNo(requestDto.getBoardNo(), requestDto.getPostsNo());
Integer groupNo;
if (requestDto.getGroupNo() != null) groupNo = requestDto.getGroupNo();
else groupNo = commentNo; // 최상위 댓글
```

그런데 정렬 순서 일괄 수정만 `groupNo` 단독으로 대상을 고릅니다. 같은 메서드 안에서 앞뒤로 이어 호출되는 조회 둘은 `boardNo`와 `postsNo`를 함께 넘깁니다.

```java
sortSeq = commentRepository.findNextSortSeq(requestDto.getBoardNo(), requestDto.getPostsNo(), ...);
if (sortSeq != null) {
    commentRepository.updateSortSeq(requestDto.getGroupNo(), sortSeq, null, 1);
} else {
    sortSeq = commentRepository.findLastSortSeq(requestDto.getBoardNo(), requestDto.getPostsNo(), ...);
}
```

같은 파일의 `findNextCommentNo`·`findLastSortSeq`·`findNextSortSeq`·`updateDeleteAt`도 모두 게시물 범위를 겁니다.

AS-IS / TO-BE

```diff
-    public Long updateSortSeq(Integer groupNo, Integer startSortSeq, Integer endSortSeq, int increaseSortSeq) {
+    public Long updateSortSeq(Integer boardNo, Integer postsNo, Integer groupNo, Integer startSortSeq, Integer endSortSeq, int increaseSortSeq) {
         return jpaQueryFactory.update(comment)
                 .set(comment.sortSeq, comment.sortSeq.add(increaseSortSeq))
-                .where(isEqualsGroupNo(groupNo),
+                .where(comment.commentId.postsId.boardNo.eq(boardNo),
+                        comment.commentId.postsId.postsNo.eq(postsNo),
+                        isEqualsGroupNo(groupNo),
```

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

한 게시판의 게시물 둘에 각각 `groupNo` 1, `sortSeq` 1과 2인 댓글을 넣고, 한쪽 게시물에만 일괄 수정을 실행해 다른 게시물이 그대로인지 확인합니다.

수정 전(RED)

```
org.opentest4j.AssertionFailedError: [다른 게시물의 댓글은 그대로여야 한다]
Expecting actual:   [2, 3]
to contain exactly (and in same order):   [1, 2]
```

수정 후(GREEN)

```
BUILD SUCCESSFUL
```

`board-service` 전체 스위트는 이 변경 전후가 같습니다 — 27건 실패이고 실패 클래스와 건수가 변경 전 `main`과 동일합니다.

## 테스트 브라우저 Test Browser

서버측 조회 범위 수정이라 브라우저와 무관합니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면 변경이 없어 첨부하지 않았습니다.
