### PR TITLE
fix(apigateway): 인가 서버가 응답하지 않을 때 게이트웨이가 무한 대기하는 문제 수정

### DIFF
--- a/backend/apigateway/build.gradle
+++ b/backend/apigateway/build.gradle
@@ -43,6 +43,7 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'io.projectreactor:reactor-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/backend/apigateway/src/main/java/org/egovframe/cloud/apigateway/config/ReactiveAuthorization.java
+++ b/backend/apigateway/src/main/java/org/egovframe/cloud/apigateway/config/ReactiveAuthorization.java
@@ -1,5 +1,6 @@
 package org.egovframe.cloud.apigateway.config;
 
+import java.time.Duration;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -50,6 +51,10 @@ import reactor.core.publisher.Mono;
 @RequiredArgsConstructor
 @Component
 public class ReactiveAuthorization implements ReactiveAuthorizationManager<AuthorizationContext> {
+
+    /** 인가 서버가 응답하지 않을 때 무한 대기하지 않도록 하는 응답 제한 시간 */
+    private static final Duration AUTHORIZATION_TIMEOUT = Duration.ofSeconds(30);
+
 
     private final WebClient.Builder webClientBuilder;
 
@@ -143,6 +148,7 @@ public class ReactiveAuthorization implements ReactiveAuthorizationManager<Autho
             .headers(httpHeaders -> httpHeaders.add(HttpHeaders.AUTHORIZATION, token))
             .retrieve()
             .bodyToMono(Boolean.class)
+            .timeout(AUTHORIZATION_TIMEOUT)
             .defaultIfEmpty(false)
             .doOnNext(granted -> log.info("Security AuthorizationDecision granted={}", granted))
             .map(AuthorizationDecision::new)

--- a/backend/apigateway/src/test/java/org/egovframe/cloud/apigateway/config/ReactiveAuthorizationUnitTest.java
+++ b/backend/apigateway/src/test/java/org/egovframe/cloud/apigateway/config/ReactiveAuthorizationUnitTest.java
@@ -3,6 +3,8 @@ package org.egovframe.cloud.apigateway.config;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.concurrent.TimeoutException;
+import java.time.Duration;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -15,6 +17,7 @@ import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.ExchangeFunction;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import reactor.test.StepVerifier;
 import reactor.core.publisher.Mono;
 
 class ReactiveAuthorizationUnitTest {
@@ -51,6 +54,19 @@ class ReactiveAuthorizationUnitTest {
         assertThatThrownBy(() -> authorization.check(Mono.empty(), authorizationContext()).block())
                 .isInstanceOf(AuthorizationServiceException.class)
                 .hasCauseInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void failsWhenAuthorizationServerNeverResponds() {
+        ExchangeFunction exchangeFunction = request -> Mono.never();
+        ReactiveAuthorization authorization = authorizationWith(exchangeFunction);
+
+        StepVerifier.withVirtualTime(() -> authorization.check(Mono.empty(), authorizationContext()))
+                .thenAwait(Duration.ofSeconds(31))
+                .expectErrorSatisfies(thrown -> assertThat(thrown)
+                        .isInstanceOf(AuthorizationServiceException.class)
+                        .hasCauseInstanceOf(TimeoutException.class))
+                .verify();
     }
 
     private ReactiveAuthorization authorizationReturning(String responseBody) {


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

게이트웨이는 모든 요청의 인가를 `user-service`에 물어봅니다. 그 호출에 응답 제한 시간이 없습니다.

```java
.retrieve()
.bodyToMono(Boolean.class)
.defaultIfEmpty(false)
```

상대가 TCP 연결은 받고 응답 본문을 주지 않는 상태가 되면 이 호출은 끝나지 않습니다.

같은 저장소의 서비스간 호출은 제한 시간을 명시합니다.

```java
// portal-service LoadBalancedRestTemplateConfig
private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(5);
private static final Duration READ_TIMEOUT = Duration.ofSeconds(30);
```

게이트웨이는 단일 진입점이라 회수되지 않는 요청이 쌓이면 영향이 더 큽니다.

AS-IS / TO-BE

```diff
     .bodyToMono(Boolean.class)
+    .timeout(AUTHORIZATION_TIMEOUT)
     .defaultIfEmpty(false)
```

형제와 같은 30초로 맞췄습니다. 기존 `onErrorMap`이 그대로 감싸므로 실패 처리 경로는 바뀌지 않습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

기존 `ReactiveAuthorizationUnitTest`의 `ExchangeFunction` 주입 방식을 그대로 쓰고, 응답하지 않는 인가 서버를 `Mono.never()`로 세웁니다. 가상 시간으로 31초를 넘겨 확인합니다.

수정 전(RED)

```
> Task :test
(테스트가 끝나지 않아 빌드가 10분을 넘겨 중단됨)
```

수정 후(GREEN)

```
BUILD SUCCESSFUL in 1s
```

`apigateway` 전체 스위트는 이 변경 전후가 같습니다 — 변경 전 17건 중 1건 실패, 변경 후 18건 중 1건 실패로 기존 실패만 남습니다.

`reactor-test`를 테스트 의존성에 추가했습니다. 같은 리액티브 모듈인 `reserve-check-service`·`reserve-item-service`·`reserve-request-service`가 이미 쓰고 있고 `apigateway`에만 없었습니다.

## 테스트 브라우저 Test Browser

서버측 호출 설정 수정이라 브라우저와 무관합니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면 변경이 없어 첨부하지 않았습니다.
