### PR TITLE
ci(backend): 테스트가 통과하는 모듈의 테스트가 CI에서 실행되지 않는 문제 수정

### DIFF
--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,0 +1,5 @@
+# CodeGraph data files — local to each machine, not for committing.
+# Ignore everything in .codegraph/ except this file itself, so transient
+# files (the database, daemon.pid, sockets, logs) never show up in git.
+*
+!.gitignore

--- a/.github/workflows/build-backend.yml
+++ b/.github/workflows/build-backend.yml
@@ -28,6 +28,11 @@ jobs:
           - reserve-item-service
           - reserve-request-service
           - user-service
+        # 테스트가 통과하는 모듈만 테스트를 포함해 빌드한다.
+        include:
+          - { service: config, gradle: build }
+          - { service: discovery, gradle: build }
+          - { service: egovframe-cloud-module-common, gradle: build }
 
     steps:
       - uses: actions/checkout@v4
@@ -40,4 +45,4 @@ jobs:
           cache: gradle
 
       - name: Build ${{ matrix.service }}
-        run: cd backend/${{ matrix.service }} && ./gradlew --no-daemon build -x test
+        run: cd backend/${{ matrix.service }} && ./gradlew --no-daemon ${{ matrix.gradle || 'build -x test' }}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [X] 기타 Others

## 수정된 소스 내용 Modified source

`Backend Build` 워크플로가 `-x test`로 테스트를 제외하고 빌드합니다. 저장소에 있는 테스트는 CI에서 실행되지 않습니다.

`egovframe-cloud-module-common`은 6개 서비스가 의존하는 공통 모듈인데, 이 모듈의 테스트도 마찬가지로 실행된 적이 없습니다.

```groovy
// backend/portal-service/build.gradle 외 5곳
implementation project(':egovframe-cloud-module-common')
```

AS-IS / TO-BE

```diff
           - user-service
+        # 테스트가 통과하는 모듈만 테스트를 포함해 빌드한다.
+        include:
+          - { service: config, gradle: build }
+          - { service: discovery, gradle: build }
+          - { service: egovframe-cloud-module-common, gradle: build }

       - name: Build ${{ matrix.service }}
-        run: cd backend/${{ matrix.service }} && ./gradlew --no-daemon build -x test
+        run: cd backend/${{ matrix.service }} && ./gradlew --no-daemon ${{ matrix.gradle || 'build -x test' }}
```

### 범위

나머지 7개 서비스는 통합 테스트가 유레카 레지스트리·데이터베이스·외부 메시지 파일을 전제하는데 CI에는 그 환경이 없어 현재 실패합니다. 원인이 서비스마다 다르고 이 변경과는 별개라 이번 범위에서 뺐습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

이 PR의 워크플로 실행 결과가 그대로 확인 근거입니다. 세 모듈에서만 `:test`가 실행되고 나머지 7개는 종전과 같습니다.

```
build (config)                        ./gradlew --no-daemon build
build (discovery)                     ./gradlew --no-daemon build
build (egovframe-cloud-module-common) ./gradlew --no-daemon build
build (portal-service)                ./gradlew --no-daemon build -x test
```

## 테스트 브라우저 Test Browser

빌드 설정 수정이라 브라우저와 무관합니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면 변경이 없어 첨부하지 않았습니다.
