### PR TITLE
fix: module-common 예외 advice 가 servlet 3개 서비스에 등록되지 않는 문제 수정

### DIFF
--- a/backend/board-service/src/main/java/org/egovframe/cloud/boardservice/BoardServiceApplication.java
+++ b/backend/board-service/src/main/java/org/egovframe/cloud/boardservice/BoardServiceApplication.java
@@ -22,7 +22,7 @@ import org.springframework.context.annotation.ComponentScan;
  *  2021/07/28    jooho       최초 생성
  * </pre>
  */
-@ComponentScan({"org.egovframe.cloud.common", "org.egovframe.cloud.boardservice"})
+@ComponentScan({"org.egovframe.cloud.common", "org.egovframe.cloud.servlet.exception", "org.egovframe.cloud.boardservice"})
 @EntityScan({"org.egovframe.cloud.servlet.domain", "org.egovframe.cloud.boardservice.domain"})
 @SpringBootApplication
 public class BoardServiceApplication {

--- a/backend/board-service/src/test/java/org/egovframe/cloud/boardservice/config/ExceptionHandlerAdviceRegistrationTest.java
+++ b/backend/board-service/src/test/java/org/egovframe/cloud/boardservice/config/ExceptionHandlerAdviceRegistrationTest.java
@@ -1,0 +1,26 @@
+package org.egovframe.cloud.boardservice.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.egovframe.cloud.servlet.exception.ExceptionHandlerAdvice;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles(profiles = "test")
+class ExceptionHandlerAdviceRegistrationTest {
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @Test
+    void 공통모듈_예외_어드바이스가_빈으로_등록된다() {
+        System.out.println("ExceptionHandlerAdvice beans = "
+                + applicationContext.getBeansOfType(ExceptionHandlerAdvice.class).keySet());
+
+        assertThat(applicationContext.getBeansOfType(ExceptionHandlerAdvice.class)).isNotEmpty();
+    }
+}

--- a/backend/portal-service/src/main/java/org/egovframe/cloud/portalservice/PortalServiceApplication.java
+++ b/backend/portal-service/src/main/java/org/egovframe/cloud/portalservice/PortalServiceApplication.java
@@ -25,7 +25,7 @@ import org.springframework.context.annotation.ComponentScan;
  *  2021/06/30    jaeyeolkim  최초 생성
  * </pre>
  */
-@ComponentScan({"org.egovframe.cloud.common", "org.egovframe.cloud.portalservice"})
+@ComponentScan({"org.egovframe.cloud.common", "org.egovframe.cloud.servlet.exception", "org.egovframe.cloud.portalservice"})
 @EntityScan({"org.egovframe.cloud.servlet.domain", "org.egovframe.cloud.portalservice.domain"})
 @EnableFeignClients
 @EnableDiscoveryClient

--- a/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/config/ExceptionHandlerAdviceRegistrationTest.java
+++ b/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/config/ExceptionHandlerAdviceRegistrationTest.java
@@ -1,0 +1,46 @@
+package org.egovframe.cloud.portalservice.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.egovframe.cloud.servlet.exception.ExceptionHandlerAdvice;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.context.ApplicationContext;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles(profiles = "test")
+class ExceptionHandlerAdviceRegistrationTest {
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Test
+    void 공통모듈_예외_어드바이스가_빈으로_등록된다() {
+        System.out.println("ExceptionHandlerAdvice beans = "
+                + applicationContext.getBeansOfType(ExceptionHandlerAdvice.class).keySet());
+
+        assertThat(applicationContext.getBeansOfType(ExceptionHandlerAdvice.class)).isNotEmpty();
+    }
+
+    @Test
+    void 존재하지_않는_이미지_요청은_JSON_오류응답을_반환한다() {
+        ResponseEntity<String> responseEntity = restTemplate.getForEntity("/api/v1/images/no-such-unique-id", String.class);
+
+        System.out.println("status = " + responseEntity.getStatusCode()
+                + ", contentType = " + responseEntity.getHeaders().getContentType()
+                + ", body = " + responseEntity.getBody());
+
+        assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(responseEntity.getHeaders().getContentType().isCompatibleWith(MediaType.APPLICATION_JSON)).isTrue();
+        assertThat(responseEntity.getBody()).contains("\"code\":\"E003\"");
+    }
+}

--- a/backend/user-service/src/main/java/org/egovframe/cloud/userservice/UserServiceApplication.java
+++ b/backend/user-service/src/main/java/org/egovframe/cloud/userservice/UserServiceApplication.java
@@ -27,7 +27,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
  *  2026/06/26    이백행         [2026년 컨트리뷰션] @Bean 메서드의 불필요한 public 접근제어자 제거
  * </pre>
  */
-@ComponentScan({"org.egovframe.cloud.common", "org.egovframe.cloud.userservice"})
+@ComponentScan({"org.egovframe.cloud.common", "org.egovframe.cloud.servlet.exception", "org.egovframe.cloud.userservice"})
 @EntityScan({"org.egovframe.cloud.servlet.domain", "org.egovframe.cloud.userservice.domain"})
 @EnableDiscoveryClient
 @SpringBootApplication

--- a/backend/user-service/src/test/java/org/egovframe/cloud/userservice/config/ExceptionHandlerAdviceRegistrationTest.java
+++ b/backend/user-service/src/test/java/org/egovframe/cloud/userservice/config/ExceptionHandlerAdviceRegistrationTest.java
@@ -1,0 +1,26 @@
+package org.egovframe.cloud.userservice.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.egovframe.cloud.servlet.exception.ExceptionHandlerAdvice;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles(profiles = "test")
+class ExceptionHandlerAdviceRegistrationTest {
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @Test
+    void 공통모듈_예외_어드바이스가_빈으로_등록된다() {
+        System.out.println("ExceptionHandlerAdvice beans = "
+                + applicationContext.getBeansOfType(ExceptionHandlerAdvice.class).keySet());
+
+        assertThat(applicationContext.getBeansOfType(ExceptionHandlerAdvice.class)).isNotEmpty();
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`org.egovframe.cloud.servlet.exception.ExceptionHandlerAdvice`는 `BusinessException` 계열을 `ErrorResponse` JSON 으로 바꾸는 전역 예외 핸들러인데, servlet 계열 세 서비스의 `@ComponentScan` 이 이 클래스를 스캔하지 않아 빈으로 등록되지 않습니다.

- `portal-service/.../PortalServiceApplication.java:28`
- `board-service/.../BoardServiceApplication.java:25`
- `user-service/.../UserServiceApplication.java:30`

세 곳 모두 `{"org.egovframe.cloud.common", "<자기패키지>"}` 뿐입니다.

저장소가 이 advice 를 전제로 쓰고 있습니다. `EntityNotFoundException.java:9` 의 javadoc 은 "ExceptionHandlerAdvice BusinessException 처리 메소드에서 잡아낸다"고 적고, `ErrorCode.java:26` 은 `ENTITY_NOT_FOUND(400, "E003", ...)` 로 400 을 선언합니다. 그런데 실제 응답은 500 이고 JSON 도 아닙니다.

`2f2c3bc`("인증처리, JWT 라이브러리 업데이트")가 여섯 Application 에서 `"org.egovframe.cloud.servlet"`·`"org.egovframe.cloud.reactive"` 를 지울 때, 계속 필요한 클래스는 같은 커밋 안에서 서비스별로 복제했습니다. servlet 세 곳은 `<service>/config/AuthenticationFilter.java` 로, reactive 세 곳은 `AuthenticationConverter.java` 로 옮겼습니다. 예외 advice 만 복제도 재등록도 되지 않았습니다.

### 수정

세 Application 의 `@ComponentScan` 에 `"org.egovframe.cloud.servlet.exception"` 을 한 항목씩 추가했습니다(3줄).

패키지 전체가 아니라 `exception` 하위만 넣은 이유는 `org.egovframe.cloud.servlet` 아래에 스프링 빈이 다섯 개 있기 때문입니다 — `config/WebMvcConfig`, `config/JpaConfig`, `config/UserAuditAware`, `service/ApiLogService`, 그리고 `exception/ExceptionHandlerAdvice`. 앞의 셋은 서비스별 설정과 중복 등록될 수 있어 이번 범위에서 뺐습니다.

reactive 세 서비스(`reserve-check`·`reserve-item`·`reserve-request`)도 같은 형태로 `org.egovframe.cloud.reactive.exception` 이 빠져 있습니다. advice 클래스가 다르고 검증 경로도 달라 이 PR 에 넣지 않았습니다.

### 영향 범위

advice 의 마지막 핸들러가 `@ExceptionHandler(Exception.class)`(`ExceptionHandlerAdvice.java:193`)입니다. 따라서 이 수정은 `BusinessException` 이 400 JSON 으로 나가게 하는 데서 그치지 않고, **세 서비스의 미처리 예외 응답도 톰캣 HTML 500 에서 `ErrorResponse` JSON 500 으로 바뀝니다.** 응답 본문 형식이 바뀌는 변경입니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

세 서비스에 `config/ExceptionHandlerAdviceRegistrationTest` 를 추가했습니다. portal 은 빈 등록과 응답을 함께 봅니다. `/api/v1/images/**` 는 `GlobalConstant.java:27` 의 permitAll 목록에 있어 인가 경로를 타지 않으므로, 없는 uniqueId 로 호출하면 `AttachmentService.java:449` 의 `EntityNotFoundException` 이 그대로 advice 까지 옵니다.

수정 전 (portal-service)

```
2 tests completed, 2 failed

공통모듈_예외_어드바이스가_빈으로_등록된다()
java.lang.AssertionError:
Expecting actual not to be empty

존재하지_않는_이미지_요청은_JSON_오류응답을_반환한다()
org.opentest4j.AssertionFailedError:
expected: 400 BAD_REQUEST
 but was: 500 INTERNAL_SERVER_ERROR

status = 500 INTERNAL_SERVER_ERROR, contentType = text/html;charset=utf-8,
body = <!doctype html><html lang="en"><head><title>HTTP Status 500 – Internal Server Error</title>...
```

세 서비스 모두 같은 상태입니다.

```
board-service   ExceptionHandlerAdvice beans = []
portal-service  ExceptionHandlerAdvice beans = []
user-service    ExceptionHandlerAdvice beans = []
```

수정 후

```
board-service   BUILD SUCCESSFUL
portal-service  BUILD SUCCESSFUL
user-service    BUILD SUCCESSFUL

ExceptionHandlerAdvice beans = [exceptionHandlerAdvice]
status = 400 BAD_REQUEST, contentType = application/json,
body = {"timestamp":"...","message":"...","status":400,"code":"E003","errors":[]}
```

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 (백엔드 응답 변경)

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

위 테스트 출력으로 대신합니다.
