### PR TITLE
chore: 저장소와 무관한 .codegraph 디렉터리 제거

### DIFF
--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,5 +1,0 @@
-# CodeGraph data files — local to each machine, not for committing.
-# Ignore everything in .codegraph/ except this file itself, so transient
-# files (the database, daemon.pid, sockets, logs) never show up in git.
-*
-!.gitignore


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [X] 기타 Others

## 수정된 소스 내용 Modified source

`.codegraph/` 는 로컬 코드 인덱싱 도구가 만드는 디렉터리입니다. #259 를 올릴 때 제 작업 환경의 이 디렉터리가 의도치 않게 함께 커밋됐습니다.

남은 파일은 `.codegraph/.gitignore` 하나(5줄)이고, 내용은 그 디렉터리 안의 나머지 파일을 git 에서 무시하라는 설정입니다. 저장소 코드·빌드·CI 어디에서도 이 경로를 참조하지 않습니다.

- 추적 파일 전수 검색(`git grep -in codegraph upstream/main`) 결과 `.codegraph/` 자신 외 참조 0건
- #259 가 함께 수정한 `.github/workflows/build-backend.yml` 도 이 경로를 쓰지 않습니다

파일 하나 삭제(−5줄)입니다.

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

코드 변경이 없어 해당하지 않습니다. 참조가 없다는 점은 위 전수 검색으로 확인했습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 (파일 삭제)
