### PR TITLE
fix(reserve-check-service): 고쳐진 재고 검증 로직의 옛 명세가 테스트로 남아 있던 문제 수정

### DIFF
--- a/backend/reserve-check-service/src/test/java/org/egovframe/cloud/reservechecksevice/domain/ReserveValidatorTest.java
+++ b/backend/reserve-check-service/src/test/java/org/egovframe/cloud/reservechecksevice/domain/ReserveValidatorTest.java
@@ -212,7 +212,7 @@ public class ReserveValidatorTest {
                 .reserveMeansId("realtime")
                 .requestStartDate(now.minusDays(1))
                 .requestEndDate(now.plusDays(5))
-                .inventoryQty(2)
+                .inventoryQty(5)
                 .build();
 
         ReserveItemResponseDto reserveItemDto = ReserveItemResponseDto.builder()
@@ -290,34 +290,6 @@ public class ReserveValidatorTest {
                 .verify();
     }
 
-    @Test
-    void checkEducation_실패_인원충분_하지만코드에러조건() {
-        LocalDateTime now = LocalDateTime.now();
-        ReserveItem item = ReserveItem.builder()
-                .reserveItemId(1L)
-                .categoryId("education")
-                .reserveMeansId("realtime")
-                .requestStartDate(now.minusDays(1))
-                .requestEndDate(now.plusDays(5))
-                .inventoryQty(5)
-                .build();
-
-        ReserveItemResponseDto reserveItemDto = ReserveItemResponseDto.builder()
-                .reserveItem(item)
-                .build();
-
-        Reserve reserve = Reserve.builder()
-                .reserveId("reserve-1")
-                .reserveItemId(1L)
-                .reserveQty(3)
-                .build();
-
-        Mono<Reserve> result = reserveValidator.checkEducation(reserveItemDto, reserve);
-
-        StepVerifier.create(result)
-                .expectError(BusinessMessageException.class)
-                .verify();
-    }
 
     @Test
     void checkReserveItems_공간_라우팅_성공() {


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`ReserveValidatorTest`의 `checkEducation` 테스트 두 건이 `main`에서 실패합니다. 두 테스트는 프로덕션 술어 및 형제 테스트와 정반대를 단언합니다.

`ReserveItemResponseDto.isPossibleInventoryQty`(`ReserveItemResponseDto.java:105`·`106`)는 `inventoryQty >= reserveQty`로 재고가 충분하면 참이고 `ReserveValidator.java:110`은 이 값이 **거짓일 때만** 오류를 냅니다. 그런데

- `checkEducation_성공`은 재고 2에 신청 5를 주고 통과를 기대합니다. 2 >= 5가 거짓이라 실제로는 오류가 납니다.
- `checkEducation_실패_인원충분_하지만코드에러조건`은 재고 5에 신청 3을 주고 오류를 기대합니다. 5 >= 3이 참이라 실제로는 통과합니다.

같은 패키지의 `ReserveValidatorEducationTest`는 "재고가 신청 인원 이상이면 통과, 미만이면 인원 부족 오류"를 단언하며 3건 모두 통과합니다. 같은 메서드를 두 테스트 클래스가 반대로 규정하고 있습니다.

### 어쩌다 이렇게 됐는지

두 테스트가 들어온 #71 시점에는 `ReserveValidator`가 부정 없이 `if (isPossibleInventoryQty(...))`로 오류를 냈습니다. 재고가 충분하면 거부하고 부족하면 통과하는 반전 상태였고 그래서 위 두 단언이 그때는 초록이었습니다. 두 번째 테스트의 이름이 "인원충분_하지만코드에러조건"인 것도 그 동작을 적은 것입니다.

#71 병합 6분 뒤 #77이 그 반전을 고치면서 올바른 의미론의 `ReserveValidatorEducationTest`를 새로 추가했지만 `ReserveValidatorTest`는 손대지 않았습니다. 고쳐진 버그의 옛 명세가 그대로 남은 상태입니다.

드러나지 않은 이유는 CI가 이 모듈의 테스트를 돌리지 않기 때문입니다. `.github/workflows/build-backend.yml:48`이 `egovframe-cloud-module-common`·`config`·`discovery`를 뺀 나머지를 `build -x test`로 실행합니다.

### 수정

- `checkEducation_성공`: 재고를 2에서 5로 바꿔 이름대로 통과하게 했습니다(1줄).
- `checkEducation_실패_인원충분_하지만코드에러조건`: #77이 그 조건을 없애 전제가 사라졌으므로 삭제했습니다. 재고 부족 시 오류는 `ReserveValidatorEducationTest`가 덮고 있습니다.

프로덕션 코드 변경은 없습니다. 테스트 파일 한 개, +1 −29입니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

`main`에서 `ReserveValidator` 관련 테스트를 돌리면 두 건이 실패합니다.

```
cd backend/reserve-check-service && ./gradlew --no-daemon test --tests '*ReserveValidator*'

ReserveValidatorTest > checkEducation_성공() FAILED
    java.lang.AssertionError at ReserveValidatorTest.java:232
ReserveValidatorTest > checkEducation_실패_인원충분_하지만코드에러조건() FAILED
    java.lang.AssertionError at ReserveValidatorTest.java:319
15 tests completed, 2 failed
```

수정 후에는 세 클래스 모두 통과합니다(`ReserveValidatorTest` 8건, `ReserveValidatorEducationTest` 3건, `ReserveValidatorCountMaxTest` 3건).

```
BUILD SUCCESSFUL
```

모듈 전체로는 `main`이 47건 중 18건 실패, 수정 후 46건 중 16건 실패입니다. 줄어든 2건이 위 두 건이고 테스트 수가 하나 준 것은 삭제분입니다. 남은 16건은 `ReserveApiControllerTest` 15건과 `ReserveCheckSeviceApplicationTests.contextLoads` 1건으로, `main`에서도 같은 상태이며 이 PR의 범위가 아닙니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 (백엔드 테스트 변경)

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

위 테스트 출력으로 대신합니다.
