### PR TITLE
fix: portal-service·user-service 의 JPA Auditing 이 꺼져 있어 감사 필드가 저장되지 않는 문제 수정

### DIFF
--- a/backend/portal-service/src/main/java/org/egovframe/cloud/portalservice/config/PortalServiceJpaConfig.java
+++ b/backend/portal-service/src/main/java/org/egovframe/cloud/portalservice/config/PortalServiceJpaConfig.java
@@ -2,11 +2,14 @@ package org.egovframe.cloud.portalservice.config;
 
 import javax.sql.DataSource;
 
+import org.egovframe.cloud.servlet.config.UserAuditAware;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.orm.jpa.JpaTransactionManager;
 import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
@@ -22,6 +25,7 @@ import jakarta.persistence.EntityManagerFactory;
  * Includes repositories from both portal-service and common module
  */
 @Configuration
+@EnableJpaAuditing(auditorAwareRef = "userAuditAware")
 @EnableJpaRepositories(
     basePackages = {
         "org.egovframe.cloud.servlet.domain",
@@ -31,6 +35,11 @@ import jakarta.persistence.EntityManagerFactory;
     transactionManagerRef = "transactionManager"
 )
 public class PortalServiceJpaConfig {
+
+    @Bean
+    AuditorAware<String> userAuditAware() {
+        return new UserAuditAware();
+    }
 
     @Primary
     @Bean(name = "entityManagerFactory")

--- a/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/domain/JpaAuditingTest.java
+++ b/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/domain/JpaAuditingTest.java
@@ -1,0 +1,60 @@
+package org.egovframe.cloud.portalservice.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.egovframe.cloud.portalservice.domain.code.Code;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import jakarta.persistence.EntityManager;
+
+/**
+ * BaseEntity 를 상속한 엔티티의 등록일시/등록자가 JPA Auditing 으로 채워지는지 확인한다.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles(profiles = "test")
+class JpaAuditingTest {
+
+    @Autowired
+    EntityManager em;
+
+    @BeforeEach
+    void setUp() {
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken("tester", null,
+                        List.of(new SimpleGrantedAuthority("ROLE_ADMIN"))));
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @Transactional
+    void 엔티티를_저장하면_등록일시와_등록자가_채워진다() {
+        Code code = Code.builder()
+                .codeId("AUDIT_TEST")
+                .codeName("감사테스트")
+                .readonly(false)
+                .sortSeq(1)
+                .useAt(true)
+                .build();
+
+        em.persist(code);
+        em.flush();
+
+        assertThat(code.getCreatedDate()).isNotNull();
+        assertThat(code.getCreatedBy()).isEqualTo("tester");
+    }
+}

--- a/backend/user-service/src/main/java/org/egovframe/cloud/userservice/config/UserServiceJpaConfig.java
+++ b/backend/user-service/src/main/java/org/egovframe/cloud/userservice/config/UserServiceJpaConfig.java
@@ -2,11 +2,14 @@ package org.egovframe.cloud.userservice.config;
 
 import javax.sql.DataSource;
 
+import org.egovframe.cloud.servlet.config.UserAuditAware;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.orm.jpa.JpaTransactionManager;
 import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
@@ -22,6 +25,7 @@ import jakarta.persistence.EntityManagerFactory;
  * Includes repositories from both user-service and common module
  */
 @Configuration
+@EnableJpaAuditing(auditorAwareRef = "userAuditAware")
 @EnableJpaRepositories(
     basePackages = {
         "org.egovframe.cloud.servlet.domain",
@@ -31,6 +35,11 @@ import jakarta.persistence.EntityManagerFactory;
     transactionManagerRef = "transactionManager"
 )
 public class UserServiceJpaConfig {
+
+    @Bean
+    AuditorAware<String> userAuditAware() {
+        return new UserAuditAware();
+    }
 
     @Primary
     @Bean(name = "entityManagerFactory")

--- a/backend/user-service/src/test/java/org/egovframe/cloud/userservice/domain/JpaAuditingTest.java
+++ b/backend/user-service/src/test/java/org/egovframe/cloud/userservice/domain/JpaAuditingTest.java
@@ -1,0 +1,55 @@
+package org.egovframe.cloud.userservice.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.egovframe.cloud.userservice.domain.role.Role;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import jakarta.persistence.EntityManager;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles(profiles = "test")
+class JpaAuditingTest {
+
+    @Autowired
+    EntityManager em;
+
+    @BeforeEach
+    void setUp() {
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken("tester", null,
+                        List.of(new SimpleGrantedAuthority("ROLE_ADMIN"))));
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @Transactional
+    void 엔티티를_저장하면_등록일시가_채워진다() {
+        Role role = Role.builder()
+                .roleId("ROLE_AUDIT_TEST")
+                .roleName("감사테스트")
+                .roleContent("감사테스트")
+                .sortSeq(1)
+                .build();
+
+        em.persist(role);
+        em.flush();
+
+        assertThat(role.getCreatedDate()).isNotNull();
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

servlet 계열 세 서비스의 엔티티는 module-common 의 같은 `BaseEntity`·`BaseTimeEntity` 를 상속하고, 감사자 구현 `UserAuditAware` 도 module-common 의 `servlet/config` 에 하나뿐입니다. 그런데 JPA Auditing 을 켜는 두 항목은 `BoardServiceJpaConfig` 에만 있습니다. `PortalServiceJpaConfig`·`UserServiceJpaConfig` 는 주석까지 같은 복제본이면서 `@EnableJpaAuditing(auditorAwareRef = "userAuditAware")`(`BoardServiceJpaConfig.java:28`)과 `userAuditAware` 빈(`같은 파일:40`)이 빠져 있습니다.

`AuditingEntityListener` 는 엔티티에 붙어 있어도(`BaseEntity.java:31`·`BaseTimeEntity.java:31`) `AuditingHandler` 빈이 없으면 아무 일도 하지 않습니다. 그래서 이 두 서비스에서는 감사 필드 넷이 모두 비어 있습니다 — `@CreatedDate`·`@LastModifiedDate`(`BaseTimeEntity.java:34,37`)와 `@CreatedBy`·`@LastModifiedBy`(`BaseEntity.java:34,38`) 입니다. 대신 채우는 곳도 없습니다. 두 서비스의 main 소스에는 이 필드들을 직접 세팅하는 코드가 없고 `@PrePersist` 도, 스키마의 트리거도 없습니다.

원래는 세 서비스 모두 켜져 있었습니다. `2f2c3bc`(2026-03-27)가 세 `@ComponentScan` 에서 `org.egovframe.cloud.servlet` 을 빼면서 module-common 의 `JpaConfig` 가 등록되지 않게 됐고, 두 달 뒤 `5c9c79b`("국정원 보안점검 반영", 2026-05-18)가 `BoardServiceJpaConfig` 에만 이 두 항목을 넣었습니다. 같은 커밋이 `PortalServiceJpaConfig`·`UserServiceJpaConfig` 는 건드리지 않았습니다.

board 에 있는 것과 같은 아홉 줄을 두 파일에 넣었습니다(삭제 없음).

```diff
 @Configuration
+@EnableJpaAuditing(auditorAwareRef = "userAuditAware")
 @EnableJpaRepositories(...)
 public class PortalServiceJpaConfig {
+
+    @Bean
+    AuditorAware<String> userAuditAware() {
+        return new UserAuditAware();
+    }
```

`@EnableJpaRepositories`·`entityManagerFactory`·`transactionManager` 는 두 서비스가 이미 각자 선언하고 있어 손대지 않았습니다.

### 나머지 서비스

JPA 를 쓰는 곳은 servlet 계열 셋(portal·board·user)이고 그중 board 만 켜져 있었습니다.

module-common 의 `servlet/config/JpaConfig` 에도 `@EnableJpaAuditing` 이 있지만(`JpaConfig.java:29`), 세 서비스의 `@ComponentScan` 이 `org.egovframe.cloud.servlet` 아래에서 `exception` 만 담고 있어 등록되지 않습니다. `servlet.config` 를 통째로 스캔에 넣으면 같은 패키지의 `WebMvcConfig`(`@Configuration`)와 `JpaConfig` 가 함께 등록되는데, `JpaConfig` 는 `@EnableJpaRepositories(basePackages = "org.egovframe.cloud.*.domain")`(`:30`)로 리포지토리 범위를 따로 잡아 각 서비스가 이미 선언한 것과 겹칩니다. 그래서 board 가 택한 방식대로 서비스별 설정에 넣었습니다.

reserve-item·reserve-request·reserve-check 는 R2DBC 라 설정 경로가 다릅니다. 이 PR 은 JPA 쪽 두 서비스만 다룹니다.

### 영향 범위

감사 대상은 두 서비스의 도메인 패키지 기준으로 portal-service 13개, user-service 6개입니다. 이들 중 해당 필드를 가진 것부터 등록일시·등록자·수정일시·수정자가 채워지기 시작합니다.

- portal-service — `BaseEntity` 상속 12개와 `BaseTimeEntity` 를 상속한 `Statistics`
- user-service — `BaseEntity` 상속 2개(`Authorization`·`User`), `BaseTimeEntity` 상속 2개(`UserFindPassword`·`LoginLog`), 그리고 `Role`·`RoleAuthorization`. 뒤의 둘은 `BaseEntity` 를 상속하지 않고 `@EntityListeners(AuditingEntityListener.class)` 를 자기 클래스에 직접 답니다. `Role` 은 `@CreatedDate`(`:67`), `RoleAuthorization` 은 `@CreatedBy`(`:61`)와 `@CreatedDate`(`:68`)를 갖습니다.

두 서비스의 운영 설정은 `ddl-auto: none` 이라(`portal-service/src/main/resources/application.yml:9`·`user-service/src/main/resources/application.yml:9`) 스키마를 하이버네이트가 만들지 않습니다. docker compose 는 `./init/` 를 `/docker-entrypoint-initdb.d/` 로 마운트하므로(`docker-compose/mysql/docker-compose.yml:16`) 실제 스키마는 `docker-compose/mysql/init/init.sql` 입니다.

이 두 서비스가 JPA 로 저장하는 테이블 중 감사 컬럼이 NOT NULL 이면서 DEFAULT 절이 없는 것이 다섯입니다.

| 테이블 | `init.sql` | 저장 경로 |
|---|---|---|
| `authorization` | 128·130행 | `AuthorizationService.java:206` |
| `banner` | 162·164행 | `BannerService.java:132` |
| `content` | 293·295행 | `ContentService.java:77` |
| `privacy` | 631·633행 | `PrivacyService.java:89` |
| `role_authorization` | 733행(`created_by` 만) | `RoleAuthorizationService.java:83` |

값이 비면 이 테이블들은 NULL 이 저장되는 것이 아니라 INSERT 가 거부됩니다. 다섯 테이블의 `created_by`·`last_modified_by` 는 NOT NULL 이면서 DEFAULT 절이 없기 때문입니다. 엔티티가 `@DynamicInsert` 를 달지 않았으면(`Authorization`·`Privacy`·`RoleAuthorization`) 하이버네이트가 그 컬럼에 NULL 을 명시로 실어 보내고, 달았으면(`Banner`·`Content`) 컬럼이 INSERT 에서 빠지는데, DEFAULT 가 없어 어느 쪽도 채워지지 않습니다.

`user_find_password` 는 `created_date` 가 NOT NULL 이고 `UserService.java:398` 에 저장 경로가 있지만 그 컬럼에는 `DEFAULT CURRENT_TIMESTAMP` 가 있고 엔티티가 `@DynamicInsert`(`UserFindPassword.java:34`)라, 빈 컬럼이 빠지면서 DB 기본값이 적용됩니다. `board` 는 감사 컬럼 조건은 같지만 portal-service 에 저장 경로가 없습니다.

`statistics` 는 `created_date` 가 nullable 이라(`init.sql:794`) 저장은 되고 값만 빕니다. 접속통계가 그 값으로 월·일 집계를 합니다(`StatisticsRepositoryImpl.java:66,97`).

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

두 서비스에 `domain/JpaAuditingTest` 를 추가했습니다. 인증 정보를 넣고 엔티티를 저장한 뒤 감사 필드를 확인합니다. portal 은 `Code`(`BaseEntity`)로 등록일시와 등록자를 함께 보고, user 는 `Role` 로 등록일시를 봅니다. `Role` 에는 `@CreatedBy` 필드가 없습니다. 테스트 프로파일은 H2 에 `ddl-auto: create-drop` 이라(`portal-service/src/test/resources/application-test.yml:13`) 스키마를 엔티티에서 생성하므로, 테스트에서는 위 NOT NULL 제약이 걸리지 않고 값이 비는 것으로 관찰됩니다.

수정 전(RED) — 추가한 `@EnableJpaAuditing` 한 줄만 주석 처리하고 돌린 결과입니다.

```
portal-service  tests=1 failures=1
  java.lang.AssertionError: Expecting actual not to be null
    at JpaAuditingTest.엔티티를_저장하면_등록일시와_등록자가_채워진다(JpaAuditingTest.java:57)

user-service    tests=1 failures=1
  java.lang.AssertionError: Expecting actual not to be null
    at JpaAuditingTest.엔티티를_저장하면_등록일시가_채워진다(JpaAuditingTest.java:53)
```

수정 후(GREEN)

```
portal-service  tests=1 failures=0 errors=0
user-service    tests=1 failures=0 errors=0
```

전체 스위트는 이 변경이 새로 깨뜨리는 것이 없습니다. `origin/main`(`5cc6e0e`)을 별도 워크트리에 두고 두 서비스를 같은 명령(`./gradlew test --continue`)으로 각각 돌려 실패한 테스트 이름 집합을 대조했습니다.

```
portal-service   origin/main  tests=133 failures=70  →  이 브랜치  tests=134 failures=70
user-service     origin/main  tests=62  failures=30  →  이 브랜치  tests=63  failures=30
```

늘어난 한 건이 추가한 `JpaAuditingTest` 이고, 실패한 이름 집합은 두 서비스 모두 양쪽이 같습니다. 기존 실패는 이 변경과 무관하게 `origin/main` 에서 이미 나던 것입니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

서버측 저장값 수정이라 브라우저와 무관합니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

위 테스트 출력으로 대신합니다.
