### PR TITLE
fix(module-common): ErrorCode.DB_CONSTRAINT_DELETE 가 중복 입력 메시지를 가리키던 문제 수정

### DIFF
--- a/backend/egovframe-cloud-module-common/src/main/java/org/egovframe/cloud/common/exception/dto/ErrorCode.java
+++ b/backend/egovframe-cloud-module-common/src/main/java/org/egovframe/cloud/common/exception/dto/ErrorCode.java
@@ -36,7 +36,7 @@ public enum ErrorCode {
     // business error code
     BUSINESS_CUSTOM_MESSAGE(400, "B001", ""), // 사용자 정의 메시지를 넘기는 business exception
     DUPLICATE_INPUT_INVALID(400, "B002", "err.duplicate.input.value"), // 중복된 값을 입력하였습니다
-    DB_CONSTRAINT_DELETE(400, "B003", "err.duplicate.input.value") // 참조하는 데이터가 있어서 삭제할 수 없습니다
+    DB_CONSTRAINT_DELETE(400, "B003", "err.db.constraint.delete") // 참조하는 데이터가 있어서 삭제할 수 없습니다
     ;
 
     private final int status;

--- a/backend/egovframe-cloud-module-common/src/test/java/org/egovframe/cloud/common/exception/ErrorCodeTest.java
+++ b/backend/egovframe-cloud-module-common/src/test/java/org/egovframe/cloud/common/exception/ErrorCodeTest.java
@@ -46,7 +46,7 @@ class ErrorCodeTest {
     }
 
     @Test
-    @DisplayName("비즈니스 에러코드의 상태코드와 코드값이 올바르게 정의되어야 한다")
+    @DisplayName("비즈니스 에러코드의 상태코드, 에러코드, 메시지 키가 올바르게 정의되어야 한다")
     void businessErrorCode_속성값_검증() {
         assertEquals(400, ErrorCode.BUSINESS_CUSTOM_MESSAGE.getStatus());
         assertEquals("B001", ErrorCode.BUSINESS_CUSTOM_MESSAGE.getCode());
@@ -54,9 +54,11 @@ class ErrorCodeTest {
 
         assertEquals(400, ErrorCode.DUPLICATE_INPUT_INVALID.getStatus());
         assertEquals("B002", ErrorCode.DUPLICATE_INPUT_INVALID.getCode());
+        assertEquals("err.duplicate.input.value", ErrorCode.DUPLICATE_INPUT_INVALID.getMessage());
 
         assertEquals(400, ErrorCode.DB_CONSTRAINT_DELETE.getStatus());
         assertEquals("B003", ErrorCode.DB_CONSTRAINT_DELETE.getCode());
+        assertEquals("err.db.constraint.delete", ErrorCode.DB_CONSTRAINT_DELETE.getMessage());
     }
 
     @Test


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`ErrorCode` 의 세 번째 필드는 `MessageSource` 키입니다. `ErrorResponse.java:49,57` 이 `code.getMessage()` 를 그대로 `messageSource.getMessage(...)` 에 넘깁니다.

`DB_CONSTRAINT_DELETE`(`ErrorCode.java:39`)의 키가 바로 윗줄 `DUPLICATE_INPUT_INVALID`(`:38`)와 같은 `err.duplicate.input.value` 입니다. 두 항목의 주석은 서로 다릅니다.

```java
DUPLICATE_INPUT_INVALID(400, "B002", "err.duplicate.input.value"), // 중복된 값을 입력하였습니다
DB_CONSTRAINT_DELETE(400, "B003", "err.duplicate.input.value") // 참조하는 데이터가 있어서 삭제할 수 없습니다
```

주석과 같은 내용을 담은 전용 키가 이미 있습니다. `message` 테이블 시드(`docker-compose/mysql/init/init.sql`)에 `err.db.constraint.delete` 행이 있고 한글 값이 "참조하는 데이터가 있어 삭제할 수 없습니다" 입니다. 프런트 로케일(`frontend/admin/public/locales/ko/common.json`·`frontend/portal/public/locales/ko/common.json`)에도 같은 값으로 들어 있습니다.

그리고 그 키는 이미 쓰이고 있습니다. 다만 `ErrorCode` 를 거치지 않고 문자열로 직접 넘깁니다.

- `CodeService.java:100` — `throw new BusinessMessageException(getMessage("err.db.constraint.delete"));`
- `LocationService.java:166` — 같은 형태

`DB_CONSTRAINT_DELETE` 의 키를 전용 키로 바꿨습니다(문자열 하나).

```diff
-    DB_CONSTRAINT_DELETE(400, "B003", "err.duplicate.input.value") // 참조하는 데이터가 있어서 삭제할 수 없습니다
+    DB_CONSTRAINT_DELETE(400, "B003", "err.db.constraint.delete") // 참조하는 데이터가 있어서 삭제할 수 없습니다
```

### 영향 범위

`DB_CONSTRAINT_DELETE` 는 현재 main 소스에서 참조가 없습니다(`grep -rn 'DB_CONSTRAINT_DELETE' backend --include=*.java` 결과가 enum 선언과 테스트뿐). 그래서 이 수정으로 지금 바뀌는 응답은 없습니다. 이 항목을 쓰는 순간 참조 무결성 오류에 "중복된 값을 입력하였습니다" 가 나가게 되어 있던 문제를 고칩니다.

이 저장소는 표준프레임워크 MSA 참조 구현이라 여기 있는 상수가 그대로 복사돼 쓰입니다. 키를 고쳐 두면 `CodeService`·`LocationService` 처럼 문자열로 우회하지 않고 이 항목을 쓸 수 있습니다. 상수를 지우는 쪽은 `B003` 코드를 폐기해도 되는가라는 별개 판단이 필요해 택하지 않았습니다.

같은 유형이 더 있는지 `ErrorCode` 14개 항목을 전부 봤습니다. `E` 계열의 주석은 대부분 `Bad Request`·`Not found` 처럼 HTTP 분류를 적은 것이라 메시지 값과 대조할 대상이 아니고, 주석을 한글 메시지 문구로 적은 것은 `B001`~`B003` 세 항목입니다.

키를 공유하는 쌍이 하나 더 있습니다. `UNAUTHORIZED`(`:27`)와 `JWT_EXPIRED`(`:28`)가 `err.unauthorized` 를 함께 씁니다. 다만 두 항목의 주석이 `The request requires an user authentication` 으로 서로 같고 상태 코드도 둘 다 401 이라 주석과 키가 어긋나지 않습니다. 401 두 경우에 같은 문구를 내보내는 의도로 보여 이번 범위에서 뺐습니다.

주석과 키가 실제로 어긋나는 것은 `DB_CONSTRAINT_DELETE` 한 건입니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

`ErrorCodeTest` 는 메시지 키를 단언하는 관례를 이미 갖고 있습니다. `errorCode_속성값_검증` 이 `INVALID_INPUT_VALUE.getMessage()` 를 보고, `businessErrorCode_속성값_검증` 도 `BUSINESS_CUSTOM_MESSAGE.getMessage().isEmpty()` 를 봅니다. 다만 비즈니스 에러코드를 보는 그 메서드에서는 `DUPLICATE_INPUT_INVALID`·`DB_CONSTRAINT_DELETE` 두 항목이 `getStatus()`·`getCode()` 까지라 이 어긋남이 통과해 왔습니다.

그 메서드에 같은 형식으로 단언 두 줄을 더했습니다. 새 테스트 메서드나 새 파일은 만들지 않았습니다. 검증 항목이 늘었으니 `@DisplayName` 도 형제 메서드와 같은 형식으로 맞췄습니다.

```diff
-    @DisplayName("비즈니스 에러코드의 상태코드와 코드값이 올바르게 정의되어야 한다")
+    @DisplayName("비즈니스 에러코드의 상태코드, 에러코드, 메시지 키가 올바르게 정의되어야 한다")
```

```diff
         assertEquals(400, ErrorCode.DUPLICATE_INPUT_INVALID.getStatus());
         assertEquals("B002", ErrorCode.DUPLICATE_INPUT_INVALID.getCode());
+        assertEquals("err.duplicate.input.value", ErrorCode.DUPLICATE_INPUT_INVALID.getMessage());
 
         assertEquals(400, ErrorCode.DB_CONSTRAINT_DELETE.getStatus());
         assertEquals("B003", ErrorCode.DB_CONSTRAINT_DELETE.getCode());
+        assertEquals("err.db.constraint.delete", ErrorCode.DB_CONSTRAINT_DELETE.getMessage());
```

수정 전(RED) — `ErrorCode.java:39` 만 원래 키로 되돌리고 돌린 결과입니다.

```
ErrorCodeTest > 비즈니스 에러코드의 상태코드, 에러코드, 메시지 키가 올바르게 정의되어야 한다 FAILED
    org.opentest4j.AssertionFailedError at ErrorCodeTest.java:61
3 tests completed, 1 failed
```

리포트의 실패 메시지는 `expected: <err.db.constraint.delete> but was: <err.duplicate.input.value>` 입니다. 같은 메서드에 함께 넣은 `DUPLICATE_INPUT_INVALID` 단언은 통과합니다. 어긋난 항목 하나만 떨어집니다.

수정 후(GREEN)

```
BUILD SUCCESSFUL
TEST-...ErrorCodeTest.xml  tests="3" skipped="0" failures="0" errors="0"
```

모듈 전체도 돌렸습니다 — `tests=14 failures=0 errors=0` 입니다. 추가한 단언은 같은 파일 `errorCode_속성값_검증` 이 `INVALID_INPUT_VALUE` 에 대해 이미 쓰는 형식 그대로입니다.

`module-common` 은 CI 가 실제로 테스트를 돌리는 모듈입니다. `build-backend.yml:33-35` 가 `config`·`discovery`·`egovframe-cloud-module-common` 셋을 `gradle: build` 로 지정하고 나머지는 `build -x test` 로 갑니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

상수 정의 수정이라 브라우저와 무관합니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

위 테스트 출력으로 대신합니다.
