### PR TITLE
fix(user-service): 이메일 중복확인에 요청 DTO 의 검증이 실행되지 않던 문제 수정

### DIFF
--- a/backend/user-service/src/main/java/org/egovframe/cloud/userservice/api/user/UserApiController.java
+++ b/backend/user-service/src/main/java/org/egovframe/cloud/userservice/api/user/UserApiController.java
@@ -166,7 +166,7 @@ public class UserApiController {
      * @return Boolean 중복 여부
      */
     @PostMapping("/api/v1/users/exists")
-    public Boolean existsEmail(@RequestBody UserEmailRequestDto requestDto) {
+    public Boolean existsEmail(@RequestBody @Valid UserEmailRequestDto requestDto) {
         return userService.existsEmail(requestDto.getEmail(), requestDto.getUserId());
     }
 

--- a/backend/user-service/src/test/java/org/egovframe/cloud/userservice/api/user/UserApiControllerExistsEmailValidationTest.java
+++ b/backend/user-service/src/test/java/org/egovframe/cloud/userservice/api/user/UserApiControllerExistsEmailValidationTest.java
@@ -1,0 +1,49 @@
+package org.egovframe.cloud.userservice.api.user;
+
+import static org.mockito.Mockito.mock;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.egovframe.cloud.common.util.MessageUtil;
+import org.egovframe.cloud.userservice.config.TokenProvider;
+import org.egovframe.cloud.userservice.service.user.UserService;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.Environment;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+/**
+ * 이메일 중복확인 요청에 UserEmailRequestDto 의 제약이 적용되는지 확인한다.
+ */
+class UserApiControllerExistsEmailValidationTest {
+
+    private final MockMvc mvc = MockMvcBuilders
+            .standaloneSetup(new UserApiController(mock(UserService.class), mock(Environment.class),
+                    mock(TokenProvider.class), mock(MessageUtil.class)))
+            .build();
+
+    @Test
+    void 이메일_형식이_아니면_400() throws Exception {
+        mvc.perform(post("/api/v1/users/exists")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"email\":\"not-an-email\"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 공백만_있는_이메일이면_400() throws Exception {
+        mvc.perform(post("/api/v1/users/exists")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"email\":\"   \"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 대조군_회원가입은_이메일_형식이_아니면_400() throws Exception {
+        mvc.perform(post("/api/v1/users/join")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"email\":\"not-an-email\",\"userName\":\"홍길동\",\"password\":\"Abcd123!xyz\"}"))
+                .andExpect(status().isBadRequest());
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`UserEmailRequestDto.email` 은 `@NotBlank` 와 `@Email` 을 선언합니다(`UserEmailRequestDto.java:37-39`). 그런데 이 DTO 를 받는 `UserApiController.existsEmail`(`:169`)에만 `@Valid` 가 없어 그 선언이 한 번도 실행되지 않습니다.

같은 클래스의 `@RequestBody` 메서드는 11개이고 나머지 10개는 모두 `@RequestBody @Valid` 입니다(`:99`·`:111`·`:158`·`:181`·`:192`·`:214`·`:225`·`:238`·`:253`·`:269`).

서비스 쪽이 대신 막아 주지도 않습니다. `UserService.existsEmail`(`:321`)의 검사는 `email == null || "".equals(email)` 이라 **공백만 있는 문자열과 이메일 형식이 아닌 문자열은 그대로 통과**합니다. 그 값이 `userRepository.findByEmail` 로 들어가 조회 결과가 없으므로 응답은 200 에 `false`, 즉 "사용 가능" 입니다.

형제 열 곳과 같은 자리에 `@Valid` 를 넣었습니다(한 줄).

```diff
-    public Boolean existsEmail(@RequestBody UserEmailRequestDto requestDto) {
+    public Boolean existsEmail(@RequestBody @Valid UserEmailRequestDto requestDto) {
```

`jakarta.validation.Valid` 는 같은 파일 `:40` 에 이미 import 되어 있습니다.

### 영향 범위

이메일 형식이 아닌 값과 공백 문자열로 오던 요청의 응답이 200 에서 400 으로 바뀝니다. `null` 과 빈 문자열은 지금도 `UserService` 가 400 을 내고 있어 상태 코드가 달라지지 않습니다.

포털의 두 호출부는 `isValidEmail` 로 먼저 거른 뒤 호출하므로(`pages/auth/join/form.tsx:95`·`components/UserInfo/UserInfoModified.tsx:46`) 대부분의 화면 입력은 서버까지 오지 않습니다. 다만 그 가드가 서버의 `@Email` 과 같은 판정을 하지는 않아, 가드는 통과하고 `@Email` 은 거부하는 입력이면 화면에서도 200 이 400 으로 바뀝니다. 두 호출부 모두 `catch` 로 오류 메시지를 표시합니다.

`@NotBlank` 의 메시지 키 `{user.email}{valid.required}` 는 같은 클래스의 회원가입이 쓰는 `UserJoinRequestDto` 와 같은 형식이라 새로 추가되는 메시지가 없습니다.

`user-service` 의 `@RequestBody` 파라미터 전수는 15개이고, `@Valid` 가 없던 것은 이 한 곳이었습니다(`RoleAuthorizationApiController` 2개·`AuthorizationApiController` 2개는 모두 `@Valid`).

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

`UserApiControllerExistsEmailValidationTest` 를 추가했습니다. `MockMvcBuilders.standaloneSetup` 으로 컨트롤러만 올려 표준 인자 처리와 JSR-380 검증만 태웁니다. 대조군으로 `@Valid` 가 이미 있는 회원가입도 같이 봅니다.

수정 전(RED)

```
UserApiControllerExistsEmailValidationTest > 공백만_있는_이메일이면_400() FAILED
UserApiControllerExistsEmailValidationTest > 이메일_형식이_아니면_400() FAILED
3 tests completed, 2 failed
```

대조군인 `대조군_회원가입은_이메일_형식이_아니면_400` 은 같은 실행에서 통과합니다. 그쪽 페이로드는 이메일만 형식을 어기고 나머지 필드는 `UserJoinRequestDto` 의 제약을 모두 만족시킵니다. 검증기가 살아 있는데 이 엔드포인트만 안 탄다는 뜻입니다.

수정 후(GREEN)

```
BUILD SUCCESSFUL
tests="3" skipped="0" failures="0" errors="0"
```

`user-service` 전체 스위트도 대조했습니다. `origin/main`(`5cc6e0e`)이 `tests=62 failures=30`, 이 브랜치가 `tests=65 failures=30` 이고 실패한 테스트 이름 집합이 같습니다. 늘어난 세 건이 추가한 테스트입니다. 기존 실패는 이 변경과 무관하게 `origin/main` 에서 이미 나던 것입니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

서버측 검증 수정이라 브라우저와 무관합니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

위 테스트 출력으로 대신합니다.
