### PR TITLE
fix(portal-service): 정책 등록과 메뉴 수정에서 선언된 필수값 검증이 실행되지 않던 문제 수정

### DIFF
--- a/backend/portal-service/src/main/java/org/egovframe/cloud/portalservice/api/menu/MenuApiController.java
+++ b/backend/portal-service/src/main/java/org/egovframe/cloud/portalservice/api/menu/MenuApiController.java
@@ -133,7 +133,7 @@ public class MenuApiController {
      */
     @PreAuthorize("hasRole('ADMIN')")
     @PutMapping(value = "/api/v1/menus/{menuId}")
-    public MenuResponseDto update(@PathVariable("menuId") Long menuId, @RequestBody MenuUpdateRequestDto updateRequestDto) {
+    public MenuResponseDto update(@PathVariable("menuId") Long menuId, @RequestBody @Valid MenuUpdateRequestDto updateRequestDto) {
         return menuService.update(menuId, updateRequestDto);
     }
 

--- a/backend/portal-service/src/main/java/org/egovframe/cloud/portalservice/api/policy/PolicyApiController.java
+++ b/backend/portal-service/src/main/java/org/egovframe/cloud/portalservice/api/policy/PolicyApiController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -90,7 +91,7 @@ public class PolicyApiController {
     @PreAuthorize("hasRole('ADMIN')")
     @PostMapping("/api/v1/policies")
     @ResponseStatus(HttpStatus.CREATED)
-    public Long save(@RequestBody PolicySaveRequestDto saveRequestDto) {
+    public Long save(@RequestBody @Valid PolicySaveRequestDto saveRequestDto) {
         return policyService.save(saveRequestDto);
     }
 

--- a/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/api/menu/MenuApiControllerTest.java
+++ b/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/api/menu/MenuApiControllerTest.java
@@ -339,6 +339,8 @@ class MenuApiControllerTest {
 
         HttpEntity<MenuUpdateRequestDto> httpEntity = new HttpEntity<>(
                 MenuUpdateRequestDto.builder()
+                        .menuKorName("parent_1")
+                        .menuEngName("parent1")
                         .description("상위메뉴")
                         .connectId(1)
                         .menuType("menuType")

--- a/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/api/menu/MenuApiControllerValidationTest.java
+++ b/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/api/menu/MenuApiControllerValidationTest.java
@@ -1,0 +1,44 @@
+package org.egovframe.cloud.portalservice.api.menu;
+
+import static org.mockito.Mockito.mock;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.egovframe.cloud.portalservice.domain.menu.SiteRepository;
+import org.egovframe.cloud.portalservice.service.menu.MenuService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+class MenuApiControllerValidationTest {
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new MenuApiController(mock(MenuService.class), mock(SiteRepository.class)))
+                .build();
+    }
+
+    @DisplayName("메뉴명이 공백 문자뿐이면 수정 요청이 거부된다")
+    @Test
+    void update_rejects_blank_menu_name() throws Exception {
+        mockMvc.perform(put("/api/v1/menus/{menuId}", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"menuKorName\":\"  \",\"menuEngName\":\"  \"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @DisplayName("메뉴명이 있으면 수정 요청이 통과한다")
+    @Test
+    void update_accepts_menu_name() throws Exception {
+        mockMvc.perform(put("/api/v1/menus/{menuId}", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"menuKorName\":\"메뉴\",\"menuEngName\":\"menu\"}"))
+                .andExpect(status().isOk());
+    }
+}

--- a/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/api/policy/PolicyApiControllerValidationTest.java
+++ b/backend/portal-service/src/test/java/org/egovframe/cloud/portalservice/api/policy/PolicyApiControllerValidationTest.java
@@ -1,0 +1,43 @@
+package org.egovframe.cloud.portalservice.api.policy;
+
+import static org.mockito.Mockito.mock;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.egovframe.cloud.portalservice.service.policy.PolicyService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+class PolicyApiControllerValidationTest {
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new PolicyApiController(mock(PolicyService.class)))
+                .build();
+    }
+
+    @DisplayName("유형이 없으면 등록 요청이 거부된다")
+    @Test
+    void save_rejects_blank_type() throws Exception {
+        mockMvc.perform(post("/api/v1/policies")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"title\":\"이용약관\"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @DisplayName("유형과 제목이 있으면 등록 요청이 통과한다")
+    @Test
+    void save_accepts_type_and_title() throws Exception {
+        mockMvc.perform(post("/api/v1/policies")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"type\":\"TOS\",\"title\":\"이용약관\"}"))
+                .andExpect(status().isCreated());
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

두 요청 DTO 가 `@NotBlank` 를 메시지 키까지 붙여 선언해 두었는데, 그 DTO 를 받는 컨트롤러에 `@Valid` 가 없어 선언이 실행되지 않습니다.

- `PolicySaveRequestDto` 의 `type`(`:32`)·`title`(`:34`) ← `PolicyApiController.save`(`:93`)
- `MenuUpdateRequestDto` 의 `menuKorName`(`:34`)·`menuEngName`(`:36`) ← `MenuApiController.update`(`:136`)

형제 컨트롤러는 등록·수정 양쪽에 `@Valid` 를 답니다 — privacy(`:100`·`:113`) · content(`:88`·`:101`) · banner(`:123`·`:135`) · code(`:97`·`:110`) · codeDetail(`:123`·`:136`). 이 중 code·codeDetail 의 `update` 는 같은 이유로 `#250` 에서 고친 자리입니다.

`MenuApiController` 는 그 반대로 붙어 있습니다. `save`(`:97`)에는 `@Valid` 가 있는데 그쪽 `MenuTreeRequestDto` 는 제약이 하나도 없고 제약을 선언한 `MenuUpdateRequestDto` 를 받는 `update` 에는 `@Valid` 가 없습니다.

두 곳에 `@Valid` 를 넣었습니다(두 줄, `PolicyApiController` 는 import 한 줄 추가).

```diff
-    public Long save(@RequestBody PolicySaveRequestDto saveRequestDto) {
+    public Long save(@RequestBody @Valid PolicySaveRequestDto saveRequestDto) {
```

```diff
-    public MenuResponseDto update(@PathVariable("menuId") Long menuId, @RequestBody MenuUpdateRequestDto updateRequestDto) {
+    public MenuResponseDto update(@PathVariable("menuId") Long menuId, @RequestBody @Valid MenuUpdateRequestDto updateRequestDto) {
```

### 왜 이 둘만인가

portal-service 에서 `@Valid` 가 없는 `@RequestBody` 는 아홉 곳입니다. 그중 요청 DTO 가 제약을 선언한 곳은 이 둘뿐이라 나머지 일곱은 이번 범위에서 뺐습니다. 붙여도 검사할 제약이 없기 때문입니다.

| 남겨 둔 곳 | DTO 의 제약 수 |
|---|---|
| `AttachmentApiController` `:112`·`:248`·`:262`·`:372` | 0 |
| `MenuApiController.saveDnD` `:110` | 0 |
| `MenuRoleApiController.save` `:67` | 0 |
| `PolicyApiController.update` `:106` | 0 |

`PolicyUpdateRequestDto` 에 제약이 없는 것이 의도인지 누락인지는 확인하지 못해 손대지 않았습니다.

`menu` 는 `#250` 에서 "`MenuService.update` 는 `validateUpdate` 훅을 따로 갖고 있어 성격이 달라" 이번 범위에서 뺀다고 적었던 자리입니다. 그 훅(`MenuService.java:173`)은 `connectId` 와 링크 url 두 가지만 보고 메뉴명은 보지 않아, 이름 필드에는 그 사유가 닿지 않습니다. 그래서 이번에 포함했습니다.

같은 형태가 user-service(`UserApiController:169`)와 reserve 계열에도 남아 있지만 서비스와 검증 경로가 달라 이 PR 은 portal-service 로 한정했습니다.

### 영향 범위

바뀌는 것이 두 갈래입니다.

`type` 이 없는 정책 등록 요청은 지금 `Policy` 엔티티의 `@Column(nullable = false, name = "type_id")`(`Policy.java:44`) 때문에 저장 단계에서 실패해 서버 오류로 나가는데, 앞으로는 컨트롤러에서 400 으로 걸립니다. 관리자 화면은 유형을 목록에서 고르게 해 두어(`pages/policy/[id].tsx:148`) 이 경우는 화면 밖 직접 호출에서만 생깁니다.

공백 문자만 있는 값은 지금 그대로 저장되다가 400 이 됩니다. 정책 제목과 메뉴명 모두 관리자 화면의 `rules` 가 `required` 로만 막고(`pages/policy/[id].tsx:205` 는 `required: true`, `components/EditForm/MenuEditForm.tsx:229`·`:256` 은 `required: true` 에 `maxLength` 가 각각 100·200) 두 파일 어디에도 `trim` 이 없어 공백은 통과합니다. `policy_title` 컬럼에는 NOT NULL 이 없어 DB 도 막지 않습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

두 컨트롤러에 `ValidationTest` 를 하나씩 추가했습니다. 형식은 이미 머지된 `CodeApiControllerValidationTest` 를 그대로 따랐습니다 — `MockMvcBuilders.standaloneSetup` 으로 컨트롤러만 올려 스프링 컨텍스트 없이 바인딩과 검증만 태웁니다.

수정 전(RED)

```
MenuApiControllerValidationTest > 메뉴명이 공백 문자뿐이면 수정 요청이 거부된다 FAILED
    java.lang.AssertionError at MenuApiControllerValidationTest.java:33
PolicyApiControllerValidationTest > 유형이 없으면 등록 요청이 거부된다 FAILED
    java.lang.AssertionError at PolicyApiControllerValidationTest.java:32
4 tests completed, 2 failed
```

리포트의 실패 메시지는 각각 `Status expected:<400> but was:<200>`·`Status expected:<400> but was:<201>` 입니다.

각 테스트의 정상 요청 대조군은 같은 실행에서 통과합니다.

수정 후(GREEN)

```
BUILD SUCCESSFUL
MenuApiControllerValidationTest    tests="2" failures="0" errors="0"
PolicyApiControllerValidationTest  tests="2" failures="0" errors="0"
```

기존 통합테스트 중 `MenuUpdateRequestDto` 를 만드는 곳을 따로 찾아 확인했습니다. `MenuApiControllerTest.메뉴관리_기본설정_저장한다`(`:341`)가 메뉴명 없이 그 DTO 를 보내고 있어 요청 DTO 에 메뉴명 두 필드를 채웠습니다(두 줄).

이 테스트의 실패 사유는 이 변경 전후가 같습니다. 양쪽 모두 `UnknownContentTypeException` 이고, 검증 앞 단계인 인증에서 이미 막혀 컨트롤러까지 오지 않습니다. 그래서 이 두 줄은 검증이 도달하게 됐을 때를 대비한 것이지 지금 무언가를 고치는 것은 아닙니다.

실패 테스트 이름 집합만 대조해서는 이런 경우를 못 잡습니다. 이미 실패하던 테스트의 실패 사유가 바뀌는 것은 집합 비교에 나타나지 않아, 위 확인은 이름 집합 대조와 별개로 했습니다.

portal-service 전체 스위트도 대조했습니다. `origin/main`(`5cc6e0e`)이 `tests=133 failures=70`, 이 브랜치가 `tests=137 failures=70` 이고 실패한 테스트 이름 집합이 같습니다. 늘어난 네 건이 추가한 테스트입니다. 기존 실패는 이 변경과 무관하게 `origin/main` 에서 이미 나던 것입니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

서버측 검증 수정이라 브라우저와 무관합니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

위 테스트 출력으로 대신합니다.
