### PR TITLE
fix(reserve-check-service): 예약 취소 사유의 필수값 검증이 실행되지 않던 문제 수정

### DIFF
--- a/backend/reserve-check-service/src/main/java/org/egovframe/cloud/reservechecksevice/api/ReserveApiController.java
+++ b/backend/reserve-check-service/src/main/java/org/egovframe/cloud/reservechecksevice/api/ReserveApiController.java
@@ -122,7 +122,7 @@ public class ReserveApiController {
      */
     @PutMapping("/api/v1/reserves/cancel/{reserveId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public Mono<Void> cancel(@PathVariable("reserveId") String reserveId, @RequestBody ReserveCancelRequestDto cancelRequestDto) {
+    public Mono<Void> cancel(@PathVariable("reserveId") String reserveId, @Valid @RequestBody ReserveCancelRequestDto cancelRequestDto) {
         return reserveService.cancel(reserveId, cancelRequestDto);
     }
 

--- a/backend/reserve-check-service/src/test/java/org/egovframe/cloud/reservechecksevice/api/ReserveCancelValidationTest.java
+++ b/backend/reserve-check-service/src/test/java/org/egovframe/cloud/reservechecksevice/api/ReserveCancelValidationTest.java
@@ -1,0 +1,79 @@
+package org.egovframe.cloud.reservechecksevice.api;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.egovframe.cloud.reservechecksevice.api.dto.ReserveCancelRequestDto;
+import org.egovframe.cloud.reservechecksevice.service.ReserveService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.Environment;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import reactor.core.publisher.Mono;
+
+/**
+ * 예약 취소 요청 본문의 취소 사유(@NotBlank)가 실제로 검증되는지 확인한다.
+ * 스프링 컨텍스트를 띄우지 않는 standalone WebFlux 바인딩이라 통합테스트 환경에 의존하지 않는다.
+ */
+class ReserveCancelValidationTest {
+
+    private ReserveService reserveService;
+    private WebTestClient webTestClient;
+
+    @BeforeEach
+    void setUp() {
+        reserveService = mock(ReserveService.class);
+        Environment env = mock(Environment.class);
+        when(reserveService.cancel(anyString(), any(ReserveCancelRequestDto.class)))
+            .thenReturn(Mono.empty());
+        webTestClient = WebTestClient
+            .bindToController(new ReserveApiController(reserveService, env))
+            .build();
+    }
+
+    @Test
+    @DisplayName("취소 사유가 공백 문자뿐이면 400 으로 거부하고 서비스를 호출하지 않는다")
+    void blankReasonIsRejected() {
+        webTestClient.put()
+            .uri("/api/v1/reserves/cancel/1")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue("{\"reasonCancelContent\":\" \"}")
+            .exchange()
+            .expectStatus().isBadRequest();
+
+        verify(reserveService, never()).cancel(anyString(), any(ReserveCancelRequestDto.class));
+    }
+
+    @Test
+    @DisplayName("취소 사유가 없으면 400 으로 거부하고 서비스를 호출하지 않는다")
+    void nullReasonIsRejected() {
+        webTestClient.put()
+            .uri("/api/v1/reserves/cancel/1")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue("{}")
+            .exchange()
+            .expectStatus().isBadRequest();
+
+        verify(reserveService, never()).cancel(anyString(), any(ReserveCancelRequestDto.class));
+    }
+
+    @Test
+    @DisplayName("취소 사유가 정상이면 204 로 처리된다")
+    void validReasonIsAccepted() {
+        webTestClient.put()
+            .uri("/api/v1/reserves/cancel/1")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue("{\"reasonCancelContent\":\"개인 사정\"}")
+            .exchange()
+            .expectStatus().isNoContent();
+
+        verify(reserveService).cancel(anyString(), any(ReserveCancelRequestDto.class));
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`ReserveCancelRequestDto.reasonCancelContent` 는 `@NotBlank` 를 선언합니다(`ReserveCancelRequestDto.java:30-31`). 그런데 이 DTO 를 받는 `ReserveApiController.cancel`(`:125`)에만 `@Valid` 가 없어 그 선언이 실행되지 않습니다.

같은 클래스의 형제 둘은 둘 다 `@Valid @RequestBody` 입니다.

- `update`(`:150`) — `@Valid @RequestBody ReserveUpdateRequestDto`
- `create`(`:163`) — `@Valid @RequestBody ReserveSaveRequestDto`

취소 사유는 화면 표시용으로 끝나지 않고 저장됩니다. `ReserveService.cancel`(`:136`)이 `reserveCancel`(`:170`)로 넘기고 거기서 `reserve.updateStatusCancel(cancelRequestDto.getReasonCancelContent())`(`:183`)를 거쳐 `reserveRepository.save`(`:189`)로 갑니다.

프런트의 클라이언트 검증은 빈 문자열만 막습니다. 두 화면 모두 `trim` 을 하지 않아 공백 문자는 통과합니다.

- 포털 — `frontend/portal/src/pages/user/reserve/cancel/[id].tsx:29` 의 `searchText.value === ''`
- 관리자 — `frontend/admin/src/components/Reserve/ReserveInofView.tsx:94` 의 `reason.length <= 0`

형제 둘과 같은 자리에 `@Valid` 를 넣었습니다(한 줄).

```diff
-    public Mono<Void> cancel(@PathVariable("reserveId") String reserveId, @RequestBody ReserveCancelRequestDto cancelRequestDto) {
+    public Mono<Void> cancel(@PathVariable("reserveId") String reserveId, @Valid @RequestBody ReserveCancelRequestDto cancelRequestDto) {
```

### 영향 범위

취소 사유가 공백 문자뿐인 요청의 응답이 204 에서 400 으로 바뀝니다. `@NotBlank` 는 원래 이 DTO 가 선언해 둔 제약입니다. 형제 두 엔드포인트도 자기 DTO 의 제약(`@NotNull` 다섯씩)을 `@Valid` 로 이미 실행하고 있습니다.

취소 사유 항목이 아예 없는 요청도 지금은 204 였다가 400 이 됩니다. 아래 테스트에 그 경우를 함께 넣었습니다.

이 400 의 응답 본문은 `ErrorResponse` 가 아니라 스프링 기본 오류 JSON 입니다. `ReserveCheckSeviceApplication.java:12` 의 `@ComponentScan` 이 `org.egovframe.cloud.reactive.exception` 을 담고 있지 않아 그 패키지의 `ExceptionHandlerAdvice` 가 등록되지 않기 때문입니다. 이 서비스의 형제 엔드포인트(`update`·`create`)가 내는 검증 400 도 지금 같은 형태이고, 관리자 화면이 그 둘을 호출합니다.

advice 등록은 이 PR 과 별개 사안이라 넣지 않았습니다. reactive 세 서비스에 함께 볼 문제이고, 등록 전후로 다른 오류 응답이 어떻게 바뀌는지 따로 재 봐야 합니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

`ReserveCancelValidationTest` 를 추가했습니다. `WebTestClient.bindToController` 로 컨트롤러만 올려 스프링 컨텍스트 없이 바인딩과 검증만 태웁니다. 거부될 때 서비스가 호출되지 않는지도 함께 봅니다.

수정 전(RED)

```
ReserveCancelValidationTest > 취소 사유가 공백 문자뿐이면 400 으로 거부하고 서비스를 호출하지 않는다 FAILED
    java.lang.AssertionError at ReserveCancelValidationTest.java:49
ReserveCancelValidationTest > 취소 사유가 없으면 400 으로 거부하고 서비스를 호출하지 않는다 FAILED
    java.lang.AssertionError at ReserveCancelValidationTest.java:62
3 tests completed, 2 failed
```

두 건 모두 리포트의 실패 메시지는 `Status expected:<400 BAD_REQUEST> but was:<204 NO_CONTENT>` 입니다.

정상 사유를 보내는 대조군은 같은 실행에서 통과합니다.

수정 후(GREEN)

```
BUILD SUCCESSFUL
tests="3" skipped="0" failures="0" errors="0"
```

`reserve-check-service` 전체 스위트도 대조했습니다. `origin/main`(`5cc6e0e`)이 `tests=47 failures=18`, 이 브랜치가 `tests=50 failures=18` 이고 실패한 테스트 이름 집합이 같습니다. 늘어난 세 건이 추가한 테스트입니다. 기존 실패는 이 변경과 무관하게 `origin/main` 에서 이미 나던 것이고 그중 `ReserveApiControllerTest` 15건은 스프링 컨텍스트가 필요한 통합테스트라 이번 재현 벡터로 쓰지 않았습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

서버측 검증 수정이라 브라우저와 무관합니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

위 테스트 출력으로 대신합니다.
