### PR TITLE
fix(reserve-check-service): 공간 예약의 신청 기간 검증이 실행되지 않던 문제 수정

### DIFF
--- a/backend/reserve-check-service/src/main/java/org/egovframe/cloud/reservechecksevice/validator/ReserveSaveValidator.java
+++ b/backend/reserve-check-service/src/main/java/org/egovframe/cloud/reservechecksevice/validator/ReserveSaveValidator.java
@@ -4,6 +4,7 @@ import java.lang.reflect.Field;
 import java.time.LocalDateTime;
 
 import org.egovframe.cloud.common.util.MessageUtil;
+import org.egovframe.cloud.reservechecksevice.domain.Category;
 import org.egovframe.cloud.reservechecksevice.validator.annotation.ReserveSaveValid;
 import org.springframework.util.StringUtils;
 
@@ -59,20 +60,20 @@ public class ReserveSaveValidator implements ConstraintValidator<ReserveSaveVali
     @Override
     public boolean isValid(Object value, ConstraintValidatorContext context) {
         String categoryId = String.valueOf(getFieldValue(value, "categoryId"));
-        if ("education".equals(categoryId)) {
+        if (Category.EDUCATION.isEquals(categoryId)) {
             //교육인 경우
             //신청인원
             return checkReserveQty(value, context);
         }
 
-        if ("equipment".equals(categoryId)) {
+        if (Category.EQUIPMENT.isEquals(categoryId)) {
             //장비인 경우
             //신청일자(기간), 신청수량
             // 두 검사를 모두 수행해 위반 사유를 함께 담는다
             return checkReserveDate(value, context) & checkReserveQty(value, context);
         }
 
-        if ("place".equals(categoryId)) {
+        if (Category.SPACE.isEquals(categoryId)) {
             //공간인 경우
             //신청일자(기간)
             return checkReserveDate(value, context);

--- a/backend/reserve-check-service/src/test/java/org/egovframe/cloud/reservechecksevice/validator/ReserveSaveValidatorCategoryTest.java
+++ b/backend/reserve-check-service/src/test/java/org/egovframe/cloud/reservechecksevice/validator/ReserveSaveValidatorCategoryTest.java
@@ -1,0 +1,136 @@
+package org.egovframe.cloud.reservechecksevice.validator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Answers.RETURNS_DEEP_STUBS;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+
+import org.egovframe.cloud.common.util.MessageUtil;
+import org.egovframe.cloud.reservechecksevice.api.dto.ReserveSaveRequestDto;
+import org.egovframe.cloud.reservechecksevice.api.dto.ReserveUpdateRequestDto;
+import org.egovframe.cloud.reservechecksevice.domain.Category;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import jakarta.validation.ConstraintValidatorContext;
+
+/**
+ * {@link ReserveSaveValidator}가 예약 유형별 분기를 실제 카테고리 키로 판정하는지 검증한다.
+ * <p>
+ * 공간 예약 분기가 {@code "place"} 를 비교하고 있었으나 세 서비스의 {@link Category} 가 쓰는 키는
+ * {@code "space"} 다. 어떤 요청도 이 분기에 들어오지 못해 공간 예약은 신청 기간 검사를 통째로
+ * 건너뛰었다. 예약 기간 두 필드에는 {@code @NotNull} 이 없어 이 검증기가 유일한 방어선이다.
+ */
+class ReserveSaveValidatorCategoryTest {
+
+    private static final LocalDateTime DAY_1 = LocalDateTime.of(2026, 3, 1, 9, 0);
+    private static final LocalDateTime DAY_2 = LocalDateTime.of(2026, 3, 2, 18, 0);
+
+    private ReserveSaveValidator validator;
+    private ConstraintValidatorContext context;
+
+    @BeforeEach
+    void setUp() {
+        validator = new ReserveSaveValidator();
+        MessageUtil messageUtil = mock(MessageUtil.class);
+        when(messageUtil.getMessage(anyString())).thenReturn("message");
+        when(messageUtil.getMessage(anyString(), any(Object[].class))).thenReturn("message");
+        ReflectionTestUtils.setField(validator, "messageUtil", messageUtil);
+        context = mock(ConstraintValidatorContext.class, RETURNS_DEEP_STUBS);
+    }
+
+    @Test
+    @DisplayName("공간 예약은 신청 기간이 뒤집혀 있으면 거부한다")
+    void spaceRejectsReversedPeriod() {
+        ReserveSaveRequestDto dto = space(DAY_2, DAY_1);
+
+        assertThat(validator.isValid(dto, context)).isFalse();
+    }
+
+    @Test
+    @DisplayName("공간 예약은 신청 기간이 없으면 거부한다")
+    void spaceRejectsMissingPeriod() {
+        assertThat(validator.isValid(space(null, null), context)).isFalse();
+        assertThat(validator.isValid(space(DAY_1, null), context)).isFalse();
+        assertThat(validator.isValid(space(null, DAY_2), context)).isFalse();
+    }
+
+    @Test
+    @DisplayName("공간 예약의 정상 신청은 통과한다")
+    void spaceAcceptsValidPeriod() {
+        assertThat(validator.isValid(space(DAY_1, DAY_2), context)).isTrue();
+    }
+
+    @Test
+    @DisplayName("공간 예약 수정도 같은 기간 검사를 받는다")
+    void spaceUpdateIsCheckedToo() {
+        ReserveUpdateRequestDto reversed = ReserveUpdateRequestDto.builder()
+                .categoryId(Category.SPACE.getKey())
+                .reserveStartDate(DAY_2)
+                .reserveEndDate(DAY_1)
+                .build();
+
+        assertThat(validator.isValid(reversed, context)).isFalse();
+    }
+
+    @Test
+    @DisplayName("교육 예약은 신청 인원을 계속 검사한다")
+    void educationStillChecksQty() {
+        ReserveSaveRequestDto noQty = ReserveSaveRequestDto.builder()
+                .categoryId(Category.EDUCATION.getKey())
+                .build();
+        ReserveSaveRequestDto withQty = ReserveSaveRequestDto.builder()
+                .categoryId(Category.EDUCATION.getKey())
+                .reserveQty(1)
+                .build();
+
+        assertThat(validator.isValid(noQty, context)).isFalse();
+        assertThat(validator.isValid(withQty, context)).isTrue();
+    }
+
+    @Test
+    @DisplayName("장비 예약은 신청 기간과 수량을 계속 검사한다")
+    void equipmentStillChecksPeriodAndQty() {
+        ReserveSaveRequestDto reversed = ReserveSaveRequestDto.builder()
+                .categoryId(Category.EQUIPMENT.getKey())
+                .reserveQty(1)
+                .reserveStartDate(DAY_2)
+                .reserveEndDate(DAY_1)
+                .build();
+        ReserveSaveRequestDto valid = ReserveSaveRequestDto.builder()
+                .categoryId(Category.EQUIPMENT.getKey())
+                .reserveQty(1)
+                .reserveStartDate(DAY_1)
+                .reserveEndDate(DAY_2)
+                .build();
+
+        assertThat(validator.isValid(reversed, context)).isFalse();
+        assertThat(validator.isValid(valid, context)).isTrue();
+    }
+
+    @Test
+    @DisplayName("알 수 없는 예약 유형은 유형별 검사 없이 통과한다")
+    void unknownCategoryIsNotChecked() {
+        ReserveSaveRequestDto unknown = ReserveSaveRequestDto.builder()
+                .categoryId("place")
+                .reserveStartDate(DAY_2)
+                .reserveEndDate(DAY_1)
+                .build();
+
+        assertThat(validator.isValid(unknown, context)).isTrue();
+    }
+
+    private ReserveSaveRequestDto space(LocalDateTime startDate, LocalDateTime endDate) {
+        return ReserveSaveRequestDto.builder()
+                .categoryId(Category.SPACE.getKey())
+                .reserveStartDate(startDate)
+                .reserveEndDate(endDate)
+                .build();
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`ReserveSaveValidator.isValid` 의 공간 예약 분기가 `categoryId` 를 `"place"` 와 비교합니다. 그런데 세 서비스의 `Category` enum 이 쓰는 키는 모두 `"space"` 이고 포털도 예약 물품이 알려준 값을 그대로 보냅니다. 이 분기는 어떤 요청으로도 참이 되지 않아 공간 예약은 유형별 검사 없이 통과합니다. `"place"` 는 저장소 전체에서 이 분기와 `ReserveApiControllerTest` 픽스처 두 곳에만 있습니다.

`ReserveSaveRequestDto` 의 `reserveStartDate` 와 `reserveEndDate` 에는 `@NotNull` 이 없어 이 검증기가 유일한 방어선입니다. 그래서 둘이 통과합니다. 기간이 없으면 `ReserveValidator.checkReserveDate` 의 `reserve.getReserveStartDate()` 에서 `NullPointerException` 이 나고, 시작일이 종료일보다 뒤인 예약은 그대로 저장됩니다.

뒤집힌 예약은 이후 겹침 검사에도 걸리지 않습니다. `findAllByReserveDateWithoutSelfCount` 는 `reserve_start_date <= 신청종료일 and reserve_end_date >= 신청시작일` 인 행을 찾는데, 저장된 행의 시작이 종료보다 뒤이면 두 조건이 모두 거짓이라 같은 공간의 다른 신청이 충돌로 잡히지 않습니다.

세 분기를 `Category` enum 의 `isEquals` 로 바꿨습니다. 이 메서드는 `Category` 에 이미 있고 같은 서비스의 `ReserveValidator` 가 예약 물품 유형 판정에 쓰고 있습니다. 리터럴을 없애 같은 오타가 다시 나면 컴파일이 실패합니다. 교육과 장비 분기는 키가 맞아 동작이 바뀌지 않습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`ReserveSaveValidatorCategoryTest` 7건을 추가했습니다. 공간 예약의 기간 역전과 기간 누락, 수정 요청 경로, 정상 신청, 교육과 장비 분기 회귀, 알 수 없는 유형을 확인합니다. 검증기를 직접 호출하므로 외부 의존이 없습니다.

본체 수정만 되돌리면 4건이 실패합니다. 공간 관련 3건과, `"place"` 를 실제 유형으로 취급해 거부하는 1건입니다.

`reserve-check-service` 는 `main` 에서 이미 18건이 실패합니다. 이 변경 전후 모두 같은 18건이고 새로 실패하는 테스트는 없습니다. 47건에서 54건이 되며 늘어난 7건이 모두 통과합니다. JDK 17, Gradle 8.5 에서 확인했습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

서버 측 검증 로직이라 브라우저 테스트는 해당하지 않습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면 변경이 없어 첨부하지 않았습니다.
