### PR TITLE
fix(reserve-check-service): 예약 수정이 아직 차감되지 않은 재고를 다시 차감하는 문제 수정

### DIFF
--- a/backend/reserve-check-service/src/main/java/org/egovframe/cloud/reservechecksevice/service/ReserveService.java
+++ b/backend/reserve-check-service/src/main/java/org/egovframe/cloud/reservechecksevice/service/ReserveService.java
@@ -307,6 +307,11 @@ public class ReserveService extends ReactiveAbstractService {
      * 사용자 예약 수정
      *
      * @param reserveId
+     * <p>
+     * 재고는 반영하지 않는다. 이 메서드에 도달하는 예약은 아래 isRequest 검사 때문에 예약 신청 상태뿐이고,
+     * 그 상태는 아직 재고가 차감되지 않은 상태다. 심사가 필요한 신청은 reserve-request-service 가
+     * 재고를 건드리지 않고 신청 상태로 저장하며, 차감은 승인 시 checkApprove 가 한 번 수행한다.
+     *
      * @param updateRequestDto
      * @return
      */
@@ -329,8 +334,6 @@ public class ReserveService extends ReactiveAbstractService {
             })
             .flatMap(validator::checkReserveItems)
             .onErrorResume(Mono::error)
-            .flatMap(this::updateInventory)
-            .onErrorResume(Mono::error)
             .flatMap(reserveRepository::save);
     }
 
@@ -338,6 +341,9 @@ public class ReserveService extends ReactiveAbstractService {
      * 관리자 예약 수정
      *
      * @param reserveId
+     * <p>
+     * 재고는 반영하지 않는다. 이유는 {@link #updateReserveForUser} 와 같다.
+     *
      * @param updateRequestDto
      * @return
      */
@@ -353,8 +359,6 @@ public class ReserveService extends ReactiveAbstractService {
                 return reserve.updateByAdmin(updateRequestDto);
             })
             .flatMap(validator::checkReserveItems)
-            .onErrorResume(Mono::error)
-            .flatMap(this::updateInventory)
             .onErrorResume(Mono::error)
             .flatMap(reserveRepository::save);
     }

--- a/backend/reserve-check-service/src/test/java/org/egovframe/cloud/reservechecksevice/service/ReserveServiceUpdateInventoryTest.java
+++ b/backend/reserve-check-service/src/test/java/org/egovframe/cloud/reservechecksevice/service/ReserveServiceUpdateInventoryTest.java
@@ -1,0 +1,171 @@
+package org.egovframe.cloud.reservechecksevice.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.egovframe.cloud.common.domain.Role;
+import org.egovframe.cloud.common.util.MessageUtil;
+import org.egovframe.cloud.reservechecksevice.api.dto.ReserveUpdateRequestDto;
+import org.egovframe.cloud.reservechecksevice.client.ReserveItemServiceClient;
+import org.egovframe.cloud.reservechecksevice.domain.Reserve;
+import org.egovframe.cloud.reservechecksevice.domain.ReserveRepository;
+import org.egovframe.cloud.reservechecksevice.domain.ReserveStatus;
+import org.egovframe.cloud.reservechecksevice.domain.ReserveValidator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.cloud.stream.function.StreamBridge;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+/**
+ * 예약 수정이 재고를 다시 차감하지 않는지 검증한다.
+ * <p>
+ * 수정 경로는 예약 신청 상태만 통과시키는데, 그 상태는 아직 재고가 차감되지 않은 상태다.
+ * 심사가 필요한 신청은 reserve-request-service 가 재고를 건드리지 않고 신청 상태로 저장하고,
+ * 차감은 승인 시 한 번 일어난다. 수정에서 다시 차감하면 수정 횟수만큼 재고가 더 깎인다.
+ */
+class ReserveServiceUpdateInventoryTest {
+
+    private static final String RESERVE_ID = "r1";
+    private static final Long RESERVE_ITEM_ID = 1L;
+    private static final String USER_ID = "user";
+
+    private ReserveRepository reserveRepository;
+    private ReserveItemServiceClient reserveItemServiceClient;
+    private ReserveValidator validator;
+    private ReserveService service;
+
+    @BeforeEach
+    void setUp() {
+        reserveRepository = mock(ReserveRepository.class);
+        reserveItemServiceClient = mock(ReserveItemServiceClient.class);
+        validator = mock(ReserveValidator.class);
+        StreamBridge streamBridge = mock(StreamBridge.class);
+        service = new ReserveService(reserveRepository, reserveItemServiceClient,
+            CircuitBreakerRegistry.ofDefaults(), streamBridge, validator);
+
+        MessageUtil messageUtil = mock(MessageUtil.class);
+        when(messageUtil.getMessage(anyString())).thenAnswer(i -> i.getArgument(0));
+        when(messageUtil.getMessage(anyString(), any(Object[].class))).thenAnswer(i -> i.getArgument(0));
+        ReflectionTestUtils.setField(service, "messageUtil", messageUtil);
+
+        when(validator.checkReserveItems(any())).thenAnswer(i -> Mono.just(i.getArgument(0)));
+        when(reserveRepository.save(any())).thenAnswer(i -> Mono.just(i.getArgument(0)));
+        // 재고 차감이 성공하도록 미리 응답을 준다. 이렇게 해야 수정 경로가 재고를 건드릴 때
+        // 흐름이 끝까지 진행되고, 호출 여부만으로 판정이 갈린다.
+        when(reserveItemServiceClient.updateInventory(anyLong(), anyInt())).thenReturn(Mono.just(true));
+    }
+
+    @Test
+    @DisplayName("신청자가 예약을 수정해도 재고를 차감하지 않는다")
+    void userUpdateDoesNotTouchInventory() {
+        when(reserveRepository.findById(RESERVE_ID))
+            .thenReturn(Mono.just(educationReserve(ReserveStatus.REQUEST.getKey(), 4)));
+
+        StepVerifier.create(service.update(RESERVE_ID, updateRequest(6))
+                .contextWrite(ReactiveSecurityContextHolder.withAuthentication(userAuthentication())))
+            .expectNextCount(1)
+            .verifyComplete();
+
+        verify(reserveItemServiceClient, never()).updateInventory(anyLong(), anyInt());
+    }
+
+    @Test
+    @DisplayName("관리자가 예약을 수정해도 재고를 차감하지 않는다")
+    void adminUpdateDoesNotTouchInventory() {
+        when(reserveRepository.findById(RESERVE_ID))
+            .thenReturn(Mono.just(educationReserve(ReserveStatus.REQUEST.getKey(), 4)));
+
+        StepVerifier.create(service.update(RESERVE_ID, updateRequest(6))
+                .contextWrite(ReactiveSecurityContextHolder.withAuthentication(adminAuthentication())))
+            .expectNextCount(1)
+            .verifyComplete();
+
+        verify(reserveItemServiceClient, never()).updateInventory(anyLong(), anyInt());
+    }
+
+    @Test
+    @DisplayName("여러 번 수정한 뒤 승인하면 재고는 마지막 인원으로 한 번만 차감된다")
+    void inventoryIsDeductedOnceOnApprovalAfterRepeatedUpdates() {
+        when(reserveRepository.findById(RESERVE_ID))
+            .thenReturn(Mono.just(educationReserve(ReserveStatus.REQUEST.getKey(), 4)));
+        StepVerifier.create(service.update(RESERVE_ID, updateRequest(6))
+                .contextWrite(ReactiveSecurityContextHolder.withAuthentication(userAuthentication())))
+            .expectNextCount(1)
+            .verifyComplete();
+        StepVerifier.create(service.update(RESERVE_ID, updateRequest(5))
+                .contextWrite(ReactiveSecurityContextHolder.withAuthentication(userAuthentication())))
+            .expectNextCount(1)
+            .verifyComplete();
+
+        Reserve approved = educationReserve(ReserveStatus.REQUEST.getKey(), 5);
+        when(reserveRepository.updateStatusIfCurrentStatusIn(eq(RESERVE_ID), any(), anyString()))
+            .thenReturn(Mono.just(1L));
+        when(reserveRepository.findById(RESERVE_ID)).thenReturn(Mono.just(approved));
+
+        StepVerifier.create(service.approve(RESERVE_ID)
+                .contextWrite(ReactiveSecurityContextHolder.withAuthentication(adminAuthentication())))
+            .verifyComplete();
+
+        verify(reserveItemServiceClient, times(1)).updateInventory(RESERVE_ITEM_ID, 5);
+    }
+
+    private ReserveUpdateRequestDto updateRequest(Integer reserveQty) {
+        return ReserveUpdateRequestDto.builder()
+            .reserveItemId(RESERVE_ITEM_ID)
+            .categoryId("education")
+            .reserveQty(reserveQty)
+            .reservePurposeContent("test")
+            .reserveStartDate(LocalDateTime.of(2026, 3, 1, 0, 0))
+            .reserveEndDate(LocalDateTime.of(2026, 3, 2, 0, 0))
+            .userId(USER_ID)
+            .userContactNo("01000000000")
+            .userEmail("user@example.com")
+            .build();
+    }
+
+    private Reserve educationReserve(String status, Integer reserveQty) {
+        return Reserve.builder()
+            .reserveId(RESERVE_ID)
+            .reserveItemId(RESERVE_ITEM_ID)
+            .categoryId("education")
+            .reserveQty(reserveQty)
+            .reservePurposeContent("test")
+            .reserveStartDate(LocalDateTime.of(2026, 3, 1, 0, 0))
+            .reserveEndDate(LocalDateTime.of(2026, 3, 2, 0, 0))
+            .reserveStatusId(status)
+            .userId(USER_ID)
+            .userContactNo("01000000000")
+            .userEmail("user@example.com")
+            .build();
+    }
+
+    private Authentication userAuthentication() {
+        return new UsernamePasswordAuthenticationToken(USER_ID, "",
+            List.of(new SimpleGrantedAuthority(Role.USER.getKey())));
+    }
+
+    private Authentication adminAuthentication() {
+        return new UsernamePasswordAuthenticationToken("admin", "",
+            List.of(new SimpleGrantedAuthority(Role.ADMIN.getKey())));
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

교육 예약의 재고 차감 시점이 두 갈래입니다. 실시간·선착순은 저장 시점에 차감하고 승인 상태로 남지만, 심사가 필요한 신청은 `reserve-request-service` 의 `createRequestReserve` 가 재고를 건드리지 않고 신청 상태로 저장한 뒤 승인 시 `checkApprove` 가 한 번 차감합니다.

그런데 `updateReserveForUser` 와 `updateReserve` 가 저장 직전에 `updateInventory` 를 호출합니다. 두 메서드는 `isRequest` 검사로 신청 상태만 통과시키므로 여기 도달하는 예약은 전부 아직 차감되지 않은 상태인데, 원격 호출은 `inventoryQty - reserveQty` 로 차감하고 넘기는 값은 변경분이 아니라 새 인원 전량입니다.

그래서 수정할 때마다 새 인원이 그대로 빠집니다. 정원 30 인 강좌에 4명으로 신청한 뒤 6명, 다시 5명으로 고치면 6과 5가 차감되고 승인 시 5가 더 차감돼 합계 16 이 빠집니다. 실제로 빠져야 하는 값은 5 입니다. 수정 횟수가 N 이면 차감은 N+1 회입니다.

정원이 실제보다 적게 남은 것으로 보여 뒤이은 정상 신청이 마감으로 거절되고, 담당자가 정원을 늘려 맞추면 반대로 초과 접수가 됩니다. 예외가 없어 로그로도 드러나지 않습니다.

두 수정 경로에서 `updateInventory` 호출을 제거했습니다. 승인 시 차감을 담당하는 `checkApprove` 의 호출은 그대로 두었습니다.

이것으로 충분한 근거는 셋입니다. 두 수정 경로 모두 `isRequest` 가 아니면 예외를 던지므로 도달하는 예약은 신청 상태뿐이고, 신청 상태를 만드는 곳은 `createRequestReserve` 하나이며 그 경로에 재고 차감이 없고, 관리자 직접 생성은 관리자 화면이 상태를 `approve` 로 보내므로 수정 대상이 아닙니다. 판단 근거를 두 메서드 javadoc 에 적었습니다.

차이만 반영하는 방법과 차감 여부를 플래그로 들고 판단하는 방법도 검토했습니다. 전자는 미차감 상태에서 출발해 기준값이 없고, 후자는 도메인과 스키마가 늘어납니다. 현재 설계가 이미 승인 시 한 번 차감이므로 그 규칙을 어기던 호출을 제거하는 쪽을 택했습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`ReserveServiceUpdateInventoryTest` 3건을 추가했습니다. 신청자 수정과 관리자 수정이 재고를 건드리지 않는지, 두 번 수정한 뒤 승인했을 때 마지막 인원으로 한 번만 차감되는지 확인하며 원격 클라이언트 호출 횟수를 직접 셉니다.

본체 수정만 되돌리면 3건이 전부 실패합니다. 수정 경로 두 건은 `NeverWantedButInvoked`, 승인 건은 `TooManyActualInvocations` 입니다.

`reserve-check-service` 는 `main` 에서 이미 16건이 실패합니다(`ReserveApiControllerTest` 15건, `ReserveCheckSeviceApplicationTests` 1건). 이 변경 전후 모두 같은 16건이고 새로 실패하는 테스트는 없습니다. 56건에서 59건이 되며 늘어난 3건이 모두 통과합니다. JDK 17, Gradle 8.5 에서 확인했습니다.

수정 대상 API 인 `PUT /api/v1/reserves/{reserveId}` 는 위 16건에 속한 `ReserveApiControllerTest` 가 컨텍스트를 띄우지 못해 통합 테스트로는 검증하지 못했습니다. 그래서 서비스 계층 단위 테스트로 원격 호출 여부를 셌습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

서비스 계층 로직이라 브라우저 테스트는 해당하지 않습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면 변경이 없어 첨부하지 않았습니다. 대신 정원 30 인 강좌에서 4명으로 신청한 뒤 두 번 수정하고 승인했을 때의 차감 내역을 정리했습니다.

| 동작 | 수정 전 차감 | 수정 후 차감 |
| --- | --- | --- |
| 심사형 신청 (4명) | 0 | 0 |
| 수정 (4 → 6명) | 6 | 0 |
| 수정 (6 → 5명) | 5 | 0 |
| 승인 | 5 | 5 |
| 합계 | **16** | **5** |
