### PR TITLE
test(config): Actuator 엔드포인트 통합 테스트 추가

### DIFF
--- a/backend/config/src/test/java/org/egovframe/cloud/config/ConfigApplicationTests.java
+++ b/backend/config/src/test/java/org/egovframe/cloud/config/ConfigApplicationTests.java
@@ -1,13 +1,65 @@
 package org.egovframe.cloud.config;
 
-import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
+import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * Config Server 애플리케이션의 Actuator 엔드포인트가 정상적으로 동작하는지 검증한다.<br>
+ * 테스트마다 임의의 포트로 애플리케이션을 실행하여 실제 HTTP 요청과 응답을 확인한다.<br>
+ *
+ * @author 공통컴포넌트 개발팀 홍길동
+ * @since 2026-09-08
+ * @version 5.0.1
+ * @see
+ *
+ *      <pre>
+ *  == 개정이력(Modification Information) ==
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2026-09-08  이백행          [2026년 컨트리뷰션] 최초 생성
+ *      </pre>
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class ConfigApplicationTests {
 
-    @Test
-    void contextLoads() {
-    }
+	/** 테스트 서버에 HTTP 요청을 전송하기 위한 REST 클라이언트 */
+	@Autowired
+	private TestRestTemplate restTemplate;
+
+//	@Test
+//	void contextLoads() {
+//	}
+
+	/**
+	 * 헬스 체크 엔드포인트가 정상 상태(UP)를 반환하는지 검증한다.
+	 */
+	@Test
+	void healthEndpointReturnsUp() {
+		ResponseEntity<JsonNode> response = restTemplate.getForEntity("/actuator/health", JsonNode.class);
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(response.getBody()).isNotNull();
+		assertThat(response.getBody().path("status").asText()).isEqualTo("UP");
+	}
+
+	/**
+	 * 애플리케이션 정보 엔드포인트에 정상적으로 접근할 수 있는지 검증한다.
+	 */
+	@Test
+	void infoEndpointIsAvailable() {
+		ResponseEntity<JsonNode> response = restTemplate.getForEntity("/actuator/info", JsonNode.class);
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(response.getBody()).isNotNull();
+	}
 
 }


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [x] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

## 개요

Config Server의 Actuator 엔드포인트가 실제 애플리케이션 환경에서 정상적으로 동작하는지 검증하는 통합 테스트를 추가합니다.

## 변경 사항

- 테스트 실행 시 Config Server를 임의 포트로 구동하도록 설정
- `TestRestTemplate`을 사용한 실제 HTTP 요청 기반 테스트 구성
- `/actuator/health` 응답 검증
  - HTTP 200 OK 확인
  - 응답 본문 존재 여부 확인
  - 애플리케이션 상태가 `UP`인지 확인
- `/actuator/info` 응답 검증
  - HTTP 200 OK 확인
  - 응답 본문 존재 여부 확인
- 테스트 클래스와 테스트 메서드에 설명 및 개정 이력 추가
- 기존의 빈 `contextLoads` 테스트 비활성화

## 변경 파일

- `backend/config/src/test/java/org/egovframe/cloud/config/ConfigApplicationTests.java`

## 테스트

다음 환경에서 Config Server 테스트를 실행했습니다.

- Java: `17.0.17+10`
- Gradle Wrapper: `8.5`

```shell
cd backend/config
./gradlew test --tests org.egovframe.cloud.config.ConfigApplicationTests
```

BUILD SUCCESSFUL
4 actionable tasks: 3 executed, 1 up-to-date

영향 범위
- 프로덕션 코드 및 설정 변경 없음
- Config Server 테스트 코드에만 영향
- API 및 설정의 단절적 변경 없음

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [x] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

테스트 후

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/f5a77775-7fd8-4ba0-ac57-4db654e4ec77" />

